### PR TITLE
add seasonal naive model 

### DIFF
--- a/tests/test_benchmark_global.py
+++ b/tests/test_benchmark_global.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
 
-import pytest
+import logging
 import os
 import pathlib
-import pandas as pd
-import logging
-import matplotlib.pyplot as plt
 
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+
+from tot.benchmark import (CrossValidationBenchmark, ManualBenchmark,
+                           ManualCVBenchmark, SimpleBenchmark)
 from tot.dataset import Dataset
-from tot.models import NeuralProphetModel, ProphetModel
-from tot.experiment import SimpleExperiment, CrossValidationExperiment
-from tot.benchmark import SimpleBenchmark, CrossValidationBenchmark
-from tot.benchmark import ManualBenchmark, ManualCVBenchmark
+from tot.experiment import CrossValidationExperiment, SimpleExperiment
 from tot.metrics import ERROR_FUNCTIONS
+from tot.models import NeuralProphetModel, ProphetModel
 
 log = logging.getLogger("tot.test")
 log.setLevel("WARNING")
@@ -42,7 +43,6 @@ LR = 1.0
 ERCOT_REGIONS = ["NORTH", "EAST", "FAR_WEST"]
 
 PLOT = False
-
 
 
 def test_benchmark_simple_global_modeling():
@@ -243,7 +243,9 @@ def test_benchmark_manualCV_global_modeling():
     peyton_manning_df_intersect["ds"] = overlap_dates
     peyton_manning_df_intersect["y"] = overlap_vals
     peyton_manning_df_intersect["ID"] = "df2"
-    peyton_manning_df_intersect = pd.concat((peyton_manning_df.iloc[:101],peyton_manning_df_intersect, peyton_manning_df.iloc[101:]), ignore_index=True)
+    peyton_manning_df_intersect = pd.concat(
+        (peyton_manning_df.iloc[:101], peyton_manning_df_intersect, peyton_manning_df.iloc[101:]), ignore_index=True
+    )
     peyton_manning_df_intersect["ds"] = pd.to_datetime(peyton_manning_df_intersect["ds"])
 
     metrics = ["MAE", "MSE", "RMSE", "MASE", "RMSSE", "MAPE", "SMAPE"]
@@ -299,15 +301,10 @@ def test_benchmark_manualCV_global_modeling():
 
 
 def test_benchmark_dict_global_modeling():
-    # It will be deprecated soon
-    ercot_df_aux = pd.read_csv(ERCOT_FILE)
-    ercot_dict = {}
-    for region in ERCOT_REGIONS:
-        aux = ercot_df_aux[ercot_df_aux["ID"] == region].iloc[:NROWS].copy(deep=True)
-        aux.drop("ID", axis=1, inplace=True)
-        ercot_dict[region] = aux
+    ercot_df = pd.read_csv(ERCOT_FILE)
+
     dataset_list = [
-        Dataset(df=ercot_dict, name="ercot_load", freq="H"),
+        Dataset(df=ercot_df, name="ercot_load", freq="H"),
     ]
     model_classes_and_params = [
         (
@@ -334,4 +331,3 @@ def test_benchmark_dict_global_modeling():
     results_train, results_test = benchmark.run()
 
     log.debug("{}".format(results_test))
-

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python3
 
-import pytest
+import logging
 import os
 import pathlib
-import pandas as pd
-import logging
 
+import pandas as pd
+import pytest
+
+from tot.benchmark import (CrossValidationBenchmark, ManualBenchmark,
+                           ManualCVBenchmark, SimpleBenchmark)
 from tot.dataset import Dataset
-from tot.models import NeuralProphetModel, ProphetModel, SeasonalNaiveModel
-from tot.experiment import SimpleExperiment, CrossValidationExperiment
-from tot.benchmark import SimpleBenchmark, CrossValidationBenchmark
-from tot.benchmark import ManualBenchmark, ManualCVBenchmark
+from tot.experiment import CrossValidationExperiment, SimpleExperiment
 from tot.metrics import ERROR_FUNCTIONS
+from tot.models import NeuralProphetModel, ProphetModel, SeasonalNaiveModel
 
 log = logging.getLogger("tot.test")
 log.setLevel("WARNING")
@@ -102,22 +103,45 @@ def test_prophet_for_global_modeling():
             results_train, results_test = benchmark.run()
 
 
-def test_seasonal_naive_model():
+# parameter input for test_seasonal_naive_model
+dataset_input = [
+    {"df": "peyton_manning_df", "name": "peyton_manning", "freq": "D", "seasonalities": [7, 365.25]},
+    {"df": "peyton_manning_df", "name": "peyton_manning", "freq": "D", "seasonalities": ""},
+    {"df": "peyton_manning_df_with_ID", "name": "peyton_manning", "freq": "D", "seasonalities": ""},
+]
+model_classes_and_params_input = [{"n_forecasts": 4}, {"n_forecasts": 4, "season_length": 3}]
+decorator_input = [
+    "dataset_input, model_classes_and_params_input",
+    [
+        (dataset_input[0], model_classes_and_params_input[0]),
+        (dataset_input[1], model_classes_and_params_input[1]),
+        (dataset_input[2], model_classes_and_params_input[1]),
+    ],
+]
+
+
+@pytest.mark.parametrize(*decorator_input)
+def test_seasonal_naive_model(dataset_input, model_classes_and_params_input):
     log.info("test_seasonal_naive_model")
     peyton_manning_df = pd.read_csv(PEYTON_FILE, nrows=NROWS)
     peyton_manning_df_with_ID = peyton_manning_df.copy(deep=True)
     peyton_manning_df_with_ID["ID"] = "df1"
+    df = {"peyton_manning_df": peyton_manning_df, "peyton_manning_df_with_ID": peyton_manning_df_with_ID}
     dataset_list = [
-        Dataset(df=peyton_manning_df, name="peyton_manning", freq="D"),
-        Dataset(df=peyton_manning_df_with_ID, name="peyton_manning", freq="D"),
+        Dataset(
+            df=df[dataset_input["df"]],
+            name=dataset_input["name"],
+            freq=dataset_input["freq"],
+            seasonalities=dataset_input["seasonalities"],
+        ),
     ]
     model_classes_and_params = [
-        (SeasonalNaiveModel, {"n_forecasts": 4, "K": 7}),
+        (SeasonalNaiveModel, model_classes_and_params_input),
     ]
 
     benchmark = SimpleBenchmark(
-        model_classes_and_params=model_classes_and_params,  # iterate over this list of tuples
-        datasets=dataset_list,  # iterate over this list
+        model_classes_and_params=model_classes_and_params,
+        datasets=dataset_list,
         metrics=list(ERROR_FUNCTIONS.keys()),
         test_percentage=25,
         save_dir=SAVE_DIR,
@@ -127,33 +151,47 @@ def test_seasonal_naive_model():
     results_train, results_test = benchmark.run()
     log.debug(results_test.to_string())
 
+
+# parameter input for test_seasonal_naive_model_invalid_input
+dataset_input = [
+    {"df": "peyton_manning_df", "name": "peyton_manning", "freq": "D", "seasonalities": ""},
+]
+model_classes_and_params_input = [
+    {"n_forecasts": 4},
+    {"n_forecasts": 4, "season_length": 1},
+]
+decorator_input = [
+    "dataset_input, model_classes_and_params_input",
+    [(dataset_input[0], model_classes_and_params_input[0]), (dataset_input[0], model_classes_and_params_input[1])],
+]
+
+
+@pytest.mark.parametrize(*decorator_input)
+def test_seasonal_naive_model_invalid_input(dataset_input, model_classes_and_params_input):
     log.info("Test invalid model input - Raise Assertion")
-    model_classes_and_params_invalid = [
-        (SeasonalNaiveModel, {"n_forecasts": 0, "K": 1}),
+    peyton_manning_df = pd.read_csv(PEYTON_FILE, nrows=NROWS)
+    dataset_list = [
+        Dataset(
+            df=peyton_manning_df,
+            name=dataset_input["name"],
+            freq=dataset_input["freq"],
+            seasonalities=dataset_input["seasonalities"],
+        ),
     ]
+    model_classes_and_params = [
+        (SeasonalNaiveModel, model_classes_and_params_input),
+    ]
+
     benchmark = SimpleBenchmark(
-        model_classes_and_params=model_classes_and_params_invalid,
+        model_classes_and_params=model_classes_and_params,
         datasets=dataset_list,
-        metrics=list("MASE"),
+        metrics=list(ERROR_FUNCTIONS.keys()),
         test_percentage=25,
         save_dir=SAVE_DIR,
         num_processes=1,
     )
+
     with pytest.raises(AssertionError):
         _, _ = benchmark.run()
 
-    model_classes_and_params_invalid = [
-        (SeasonalNaiveModel, {"n_forecasts": 4}),
-    ]
-    benchmark = SimpleBenchmark(
-        model_classes_and_params=model_classes_and_params_invalid,
-        datasets=dataset_list,
-        metrics=list("MASE"),
-        test_percentage=25,
-        save_dir=SAVE_DIR,
-        num_processes=1,
-    )
-    with pytest.raises(AssertionError):
-        _, _ = benchmark.run()
-
-    log.info("#### Done with test_seasonal_naive_model")
+    log.info("#### Done with test_seasonal_naive_model_invalid_input")

--- a/tot/benchmark.py
+++ b/tot/benchmark.py
@@ -6,13 +6,14 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from multiprocessing.pool import Pool
 from typing import List, Optional, Tuple, Type
+
 import numpy as np
 import pandas as pd
 
-from tot.models import Model
 from tot.dataset import Dataset
-from tot.experiment import Experiment, SimpleExperiment, CrossValidationExperiment
-
+from tot.experiment import (CrossValidationExperiment, Experiment,
+                            SimpleExperiment)
+from tot.models import Model
 
 log = logging.getLogger("tot.benchmark")
 log.info(
@@ -118,7 +119,7 @@ class CVBenchmark(Benchmark, ABC):
         ]
         models = "_".join(list(set(models)))
         stamp = str(datetime.datetime.now().strftime("%Y%m%d_%H-%M-%S-%f"))
-        name = "metrics_summary_" + models + stamp + ".csv"
+        name = ("metrics_summary_" + models + stamp + ".csv").replace("'", "").replace(":", "_")[:40]
         log.debug(name)
         df_summary.to_csv(os.path.join(save_dir, name), encoding="utf-8", index=False)
 

--- a/tot/df_utils.py
+++ b/tot/df_utils.py
@@ -1,0 +1,43 @@
+import logging
+
+import numpy as np
+import pandas as pd
+
+log = logging.getLogger("tot.df_utils")
+
+
+def reshape_raw_predictions_to_forecast_df(df, predicted, n_req_past_observations, n_req_future_observations):
+    """Turns forecast-origin-wise predictions into forecast-target-wise predictions.
+
+    Parameters
+    ----------
+        df : pd.DataFrame
+            input dataframe
+        predicted : np.array
+            Array containing the predictions
+
+    Returns
+    -------
+        pd.DataFrame
+            columns ``ds``, ``y``, optionally ``ID`` and [``yhat<i>``],
+
+            Note
+            ----
+            where yhat<i> refers to the i-step-ahead prediction for this row's datetime.
+            e.g. yhat3 is the prediction for this datetime, predicted 3 steps ago, "3 steps old".
+    """
+    cols = ["ds", "y", "ID"]  # cols to keep from df
+    fcst_df = pd.concat((df[cols],), axis=1)
+    # create a line for each forecast_lag
+    # 'yhat<i>' is the forecast for 'y' at 'ds' from i steps ago.
+    for forecast_lag in range(1, n_req_future_observations + 1):
+        forecast = predicted[:, forecast_lag - 1]
+        pad_before = n_req_past_observations + forecast_lag - 1
+        pad_after = n_req_future_observations - forecast_lag
+        yhat = np.concatenate(
+            ([np.NaN] * pad_before, forecast, [np.NaN] * pad_after)
+        )  # add pad based on n_forecasts and current forecast_lag
+        name = f"yhat{forecast_lag}"
+        fcst_df[name] = yhat
+
+    return fcst_df

--- a/tot/experiment.py
+++ b/tot/experiment.py
@@ -11,9 +11,8 @@ import pandas as pd
 from neuralprophet import df_utils
 
 from tot.dataset import Dataset
-from tot.models import Model
 from tot.metrics import ERROR_FUNCTIONS
-
+from tot.models import Model
 
 log = logging.getLogger("tot.benchmark")
 log.debug(
@@ -70,6 +69,7 @@ class Experiment(ABC):
 
     def _evaluate_model(self, model, df_train, df_test, current_fold=None):
         df_test = model.maybe_add_first_inputs_to_df(df_train, df_test)
+        self.required_past_observations = 0
         if model.n_lags is not None:
             if model.n_lags > 0:
                 self.required_past_observations = model.n_lags + model.n_forecasts

--- a/tot/experiment.py
+++ b/tot/experiment.py
@@ -42,12 +42,14 @@ class Experiment(ABC):
             data_params["seasonalities"] = self.data.seasonalities
         if hasattr(self.data, "seasonality_mode") and self.data.seasonality_mode is not None:
             data_params["seasonality_mode"] = self.data.seasonality_mode
+        if hasattr(self.data, "freq") and self.data.freq is not None:
+            data_params["freq"] = self.data.freq
         self.params.update({"_data_params": data_params})
         if not hasattr(self, "experiment_name") or self.experiment_name is None:
             self.experiment_name = "{}_{}{}".format(
                 self.data.name,
                 self.model_class.model_name,
-                "".join(["_{0}_{1}".format(k, v) for k, v in self.params.items()]),
+                r"".join([r"_{0}_{1}".format(k, v) for k, v in self.params.items()]).replace("\'","").replace(":","_"),
             )
         if not hasattr(self, "metadata") or self.metadata is None:
             self.metadata = {
@@ -72,18 +74,14 @@ class Experiment(ABC):
         self.required_past_observations = 0
         if model.n_lags is not None:
             if model.n_lags > 0:
-                self.required_past_observations = model.n_lags + model.n_forecasts
-        elif model.K is not None:
-            if model.K > 0:
-                self.required_past_observations = model.K + model.n_forecasts
-        if self.required_past_observations > len(df_train):
+                self.required_past_observations = model.n_lags
+        elif model.season_length is not None:
+            if model.season_length > 0:
+                self.required_past_observations = model.season_length
+        if self.required_past_observations + model.n_forecasts > len(df_train):
             raise ValueError("Not enough training data to create a single input sample.")
-        elif len(df_train) - self.required_past_observations < 5:
-            log.warning("Less than 5 training samples")
-        if self.required_past_observations > len(df_test):
+        if self.required_past_observations + model.n_forecasts > len(df_test):
             raise ValueError("Not enough test data to create a single input sample.")
-        elif len(df_test) - self.required_past_observations < 5:
-            log.warning("Less than 5 test samples")
         fcst_train = model.predict(df_train)
         fcst_test = model.predict(df_test)
         # remove added input lags

--- a/tot/experiment.py
+++ b/tot/experiment.py
@@ -70,14 +70,19 @@ class Experiment(ABC):
 
     def _evaluate_model(self, model, df_train, df_test, current_fold=None):
         df_test = model.maybe_add_first_inputs_to_df(df_train, df_test)
-        min_length = model.n_lags + model.n_forecasts
-        if min_length > len(df_train):
+        if model.n_lags is not None:
+            if model.n_lags > 0:
+                self.required_past_observations = model.n_lags + model.n_forecasts
+        elif model.K is not None:
+            if model.K > 0:
+                self.required_past_observations = model.K + model.n_forecasts
+        if self.required_past_observations > len(df_train):
             raise ValueError("Not enough training data to create a single input sample.")
-        elif len(df_train) - min_length < 5:
+        elif len(df_train) - self.required_past_observations < 5:
             log.warning("Less than 5 training samples")
-        if min_length > len(df_test):
+        if self.required_past_observations > len(df_test):
             raise ValueError("Not enough test data to create a single input sample.")
-        elif len(df_test) - min_length < 5:
+        elif len(df_test) - self.required_past_observations < 5:
             log.warning("Less than 5 test samples")
         fcst_train = model.predict(df_train)
         fcst_test = model.predict(df_test)

--- a/tot/models.py
+++ b/tot/models.py
@@ -300,7 +300,7 @@ class SeasonalNaiveModel(Model):
                 ----
                  *  raw data is not supported
         """
-        df, received_ID_col, received_single_time_series, received_dict, _ = df_utils.prep_or_copy_df(df)
+        df, received_ID_col, received_single_time_series, _ = df_utils.prep_or_copy_df(df)
         # Receives df with single ID column. Only single time series accepted.
         assert len(df["ID"].unique()) == 1  # TODO: add multi-ID, multi-target
 
@@ -311,9 +311,7 @@ class SeasonalNaiveModel(Model):
             forecast = reshape_raw_predictions_to_forecast_df(
                 df_i, predicted, n_req_past_observations=self.season_length, n_req_future_observations=self.n_forecasts
             )
-        fcst_df = df_utils.return_df_in_original_format(
-            forecast, received_ID_col, received_single_time_series, received_dict
-        )
+        fcst_df = df_utils.return_df_in_original_format(forecast, received_ID_col, received_single_time_series)
         return fcst_df
 
     def maybe_add_first_inputs_to_df(self, df_train, df_test):
@@ -331,12 +329,11 @@ class SeasonalNaiveModel(Model):
             pd.DataFrame
                 dataframe containing test data enlarged with season_length values.
         """
-        df_train, _, _, _, _ = df_utils.prep_or_copy_df(df_train.tail(self.season_length))
+        df_train, _, _, _ = df_utils.prep_or_copy_df(df_train.tail(self.season_length))
         (
             df_test,
             received_ID_col_test,
             received_single_time_series_test,
-            received_dict_test,
             _,
         ) = df_utils.prep_or_copy_df(df_test)
         df_test_new = pd.DataFrame()
@@ -345,7 +342,7 @@ class SeasonalNaiveModel(Model):
             df_test_i = pd.concat([df_train_i.tail(self.season_length), df_test_i], ignore_index=True)
             df_test_new = pd.concat((df_test_new, df_test_i), ignore_index=True)
         df_test = df_utils.return_df_in_original_format(
-            df_test_new, received_ID_col_test, received_single_time_series_test, received_dict_test
+            df_test_new, received_ID_col_test, received_single_time_series_test
         )
         return df_test
 
@@ -368,16 +365,8 @@ class SeasonalNaiveModel(Model):
                 dataframe containing initial data reduced by the first season_length values.
         """
         if self.season_length > 0:
-            (
-                predicted,
-                received_ID_col_pred,
-                received_single_time_series_pred,
-                received_dict_test_pred,
-                _,
-            ) = df_utils.prep_or_copy_df(predicted)
-            df, received_ID_col_df, received_single_time_series_df, received_dict_test_df, _ = df_utils.prep_or_copy_df(
-                df
-            )
+            (predicted, received_ID_col_pred, received_single_time_series_pred, _) = df_utils.prep_or_copy_df(predicted)
+            df, received_ID_col_df, received_single_time_series_df, _ = df_utils.prep_or_copy_df(df)
             predicted_new = pd.DataFrame()
             df_new = pd.DataFrame()
             for df_name, df_i in df.groupby("ID"):
@@ -386,11 +375,9 @@ class SeasonalNaiveModel(Model):
                 df_i = df_i[self.season_length :]
                 df_new = pd.concat((df_new, df_i), ignore_index=True)
                 predicted_new = pd.concat((predicted_new, predicted_i), ignore_index=True)
-            df = df_utils.return_df_in_original_format(
-                df_new, received_ID_col_df, received_single_time_series_df, received_dict_test_df
-            )
+            df = df_utils.return_df_in_original_format(df_new, received_ID_col_df, received_single_time_series_df)
             predicted = df_utils.return_df_in_original_format(
-                predicted_new, received_ID_col_pred, received_single_time_series_pred, received_dict_test_pred
+                predicted_new, received_ID_col_pred, received_single_time_series_pred
             )
         return predicted, df
 

--- a/tot/models.py
+++ b/tot/models.py
@@ -9,7 +9,8 @@ import pandas as pd
 from neuralprophet import NeuralProphet, df_utils
 
 from tot.df_utils import reshape_raw_predictions_to_forecast_df
-from tot.utils import _convert_seasonality_to_season_length, _get_seasons, convert_to_datetime
+from tot.utils import (_convert_seasonality_to_season_length, _get_seasons,
+                       convert_to_datetime)
 
 try:
     from prophet import Prophet
@@ -262,6 +263,7 @@ class SeasonalNaiveModel(Model):
 
         # re-assign _data_params
         data_params = self.params["_data_params"]
+        self.freq = data_params["freq"]
         custom_seasonalities = None
         if "seasonalities" in data_params and len(data_params["seasonalities"]) > 0:
             daily, weekly, yearly, custom_seasonalities = _get_seasons(data_params["seasonalities"])
@@ -296,21 +298,7 @@ class SeasonalNaiveModel(Model):
         self.n_lags = None  # TODO: should not be set to None. Find different solution.
 
     def fit(self, df: pd.DataFrame, freq: str):
-        """Fits the naive model.
-        Naive models do not need to be explicitly fitted. However, we store fitting-related information.
-
-        Parameters
-        ----------
-            df : pd.DataFrame
-                dataframe containing column ``ds``, ``y``, and optionally ``ID`` with all data
-            freq : str
-                frequency of the input data
-        """
-        df, received_ID_col, received_single_time_series, received_dict, _ = df_utils.prep_or_copy_df(df)
-        # Receives df with single ID column. Only single time series accepted.
-        assert len(df["ID"].unique()) == 1  # TODO: add multi-ID, multi-target
-
-        self.freq = freq
+        pass
 
     def predict(self, df: pd.DataFrame):
         """Runs the model to make predictions.

--- a/tot/models.py
+++ b/tot/models.py
@@ -259,6 +259,8 @@ class SeasonalNaiveModel(Model):
 
         ``Not supported capabilities``
         * autoregression
+        * past covariates
+        * future covariates
 
         ``Planned capabilities``
         * auto-detect season

--- a/tot/models.py
+++ b/tot/models.py
@@ -8,7 +8,8 @@ import numpy as np
 import pandas as pd
 from neuralprophet import NeuralProphet, df_utils
 
-from tot.utils import _get_seasons, convert_to_datetime
+from tot.df_utils import reshape_raw_predictions_to_forecast_df
+from tot.utils import _convert_seasonality_to_season_length, _get_seasons, convert_to_datetime
 
 try:
     from prophet import Prophet
@@ -36,7 +37,6 @@ class Model(ABC):
 
     params: dict
     model_name: str
-    model_class: Type
 
     @abstractmethod
     def fit(self, df: pd.DataFrame, freq: str):
@@ -48,17 +48,17 @@ class Model(ABC):
 
     def maybe_add_first_inputs_to_df(self, df_train, df_test):
         """
-        if historic data is used to fit the model (e.g. n_lags>0 or K>0): adds number of historic observations
-        (e.g. n_lags or K) values to start of df_test.
-        else (time-features only): returns unchanged df_test
+        if historic data is used as input to the model to make prediction: adds number of past observations
+        (e.g. n_lags or season_length) values to start of df_test.
+        else (time-features only): returns unchanged df_test.
         """
         return df_test.reset_index(drop=True)
 
     def maybe_drop_first_forecasts(self, predicted, df):
         """
-        if historic data is used to fit the model (e.g. n_lags>0 or K>0): removes first n_lags values from
-        predicted and df_test
-        else (time-features only): returns unchanged df_test
+        if historic data is used as input to the model to make prediction: removes number of past observations
+        (e.g. n_lags or season_length) values from predicted and df_test.
+        else (time-features only): returns unchanged df_test.
         """
         return predicted.reset_index(drop=True), df.reset_index(drop=True)
 
@@ -90,7 +90,7 @@ class ProphetModel(Model):
                 self.model.add_seasonality(name="{}_daily".format(str(seasonality)), period=seasonality)
         self.n_forecasts = 1
         self.n_lags = 0
-        self.K = None
+        self.season_length = None
 
     def fit(self, df: pd.DataFrame, freq: str):
         if "ID" in df.columns and len(df["ID"].unique()) > 1:
@@ -127,7 +127,7 @@ class NeuralProphetModel(Model):
                 self.model.add_seasonality(name="{}_daily".format(str(seasonality)), period=seasonality)
         self.n_forecasts = self.model.n_forecasts
         self.n_lags = self.model.n_lags
-        self.K = None
+        self.season_length = None
 
     def fit(self, df: pd.DataFrame, freq: str):
         self.freq = freq
@@ -239,54 +239,60 @@ class SeasonalNaiveModel(Model):
     A `SeasonalNaiveModel` is a naive model that forecasts future values of a target series based on past observations
     of the target series of the specified period, i.e season.
 
-    The naive models act on time series data having ``fit()`` and ``predict()`` methods. The season can be specified
-    by K steps. Therefore, the model predicts the value of `K` time steps ago. When `K>1`, it repeats the last `K`
-    values.
-
     Parameters
     ----------
-        K : int
-            the number of last time steps to repeat
+        season_length : int
+            seasonal period in number of time steps
         n_forecasts : int
-            Number of steps ahead of prediction time step to forecast.
+            number of steps ahead of prediction time step to forecast
     Note
     ----
         ``Supported capabilities``
         * univariate time series
-        * single target
-        * manually select season steps K
-        * n_forecats>1
+        * n_forecats > 1
 
         ``Not supported capabilities``
-        * autoregression
-        * past covariates
-        * future covariates
-
-        ``Planned capabilities``
-        * auto-detect season
-        * multi-variate time series only with multi-target
-        * frequency check and optional frequency conversion
+        * multivariate time series input
     """
 
     model_name: str = "SeasonalNaive"
-    model_class: Type = None  # make sense?
 
     def __post_init__(self):
         # no installation checks required
 
-        # expect no _data_params
+        # re-assign _data_params
         data_params = self.params["_data_params"]
-        assert len(data_params) == 0
-        custom_seasonalities = None  # TODO: auto-detect season from metadata
+        custom_seasonalities = None
+        if "seasonalities" in data_params and len(data_params["seasonalities"]) > 0:
+            daily, weekly, yearly, custom_seasonalities = _get_seasons(data_params["seasonalities"])
+            self.params.update({"daily_seasonality": daily})
+            self.params.update({"weekly_seasonality": weekly})
+            self.params.update({"yearly_seasonality": yearly})
+        if "seasonality_mode" in data_params and data_params["seasonality_mode"] is not None:
+            self.params.update({"seasonality_mode": data_params["seasonality_mode"]})
 
-        # Verify expected model_prams: K > 1, n_forecasts >1
+        # Verify expected model_params: season_length > 1, n_forecasts >=1
         model_params = deepcopy(self.params)
         model_params.pop("_data_params")
-        assert len(model_params) == 2, "Model parameters K and n_forecasts must be provided"
         self.n_forecasts = model_params["n_forecasts"]
-        assert self.n_forecasts > 1, "Model parameter n_forecasts must be >1. "
-        self.K = model_params["K"]  # for seasonal naive K is input parameter
-        assert self.K > 1, "Model parameter K must be >1 for seasonal naive. For K=1 select NaiveModel instead. "
+        assert self.n_forecasts >= 1, "Model parameter n_forecasts must be >=1. "
+
+        self.season_length = None
+        # always select seasonality provided by dataset first
+        if "seasonalities" in data_params and len(data_params["seasonalities"]) > 0:
+            self.season_length = _convert_seasonality_to_season_length(
+                data_params["freq"], daily, weekly, yearly, custom_seasonalities
+            )
+        elif "season_length" in model_params:
+            self.season_length = model_params["season_length"]  # for seasonal naive season_length is input parameter
+        assert self.season_length is not None, (
+            "Dataset does not provide a seasonality. Assign a seasonality to each of the datasets "
+            "OR input desired season_length as model parameter to be used for all datasets "
+            "without specified seasonality."
+        )
+        assert (
+            self.season_length > 1
+        ), "season_length must be >1 for SeasonalNaiveModel. For season_length=1 select NaiveModel instead."
         self.n_lags = None  # TODO: should not be set to None. Find different solution.
 
     def fit(self, df: pd.DataFrame, freq: str):
@@ -333,14 +339,16 @@ class SeasonalNaiveModel(Model):
         # check also no id column
         for df_name, df_i in df.groupby("ID"):
             dates, predicted = self._predict_raw(df_i)
-            forecast = self._reshape_raw_predictions_to_forecst_df(df_i, predicted)
+            forecast = reshape_raw_predictions_to_forecast_df(
+                df_i, predicted, n_req_past_observations=self.season_length, n_req_future_observations=self.n_forecasts
+            )
         fcst_df = df_utils.return_df_in_original_format(
             forecast, received_ID_col, received_single_time_series, received_dict
         )
         return fcst_df
 
     def maybe_add_first_inputs_to_df(self, df_train, df_test):
-        """Adds last K values from df_train to start of df_test.
+        """Adds last season_length values from df_train to start of df_test.
 
         Parameters
         ----------
@@ -352,30 +360,29 @@ class SeasonalNaiveModel(Model):
         Returns
         -------
             pd.DataFrame
-                dataframe containing test data enlarged with K values.
+                dataframe containing test data enlarged with season_length values.
         """
-        if self.K > 0:
-            df_train, _, _, _, _ = df_utils.prep_or_copy_df(df_train)
-            (
-                df_test,
-                received_ID_col_test,
-                received_single_time_series_test,
-                received_dict_test,
-                _,
-            ) = df_utils.prep_or_copy_df(df_test)
-            df_test_new = pd.DataFrame()
-            for df_name, df_test_i in df_test.groupby("ID"):
-                df_train_i = df_train[df_train["ID"] == df_name].copy(deep=True)
-                df_test_i = pd.concat([df_train_i.tail(self.K), df_test_i], ignore_index=True)
-                df_test_new = pd.concat((df_test_new, df_test_i), ignore_index=True)
-            df_test = df_utils.return_df_in_original_format(
-                df_test_new, received_ID_col_test, received_single_time_series_test, received_dict_test
-            )
+        df_train, _, _, _, _ = df_utils.prep_or_copy_df(df_train.tail(self.season_length))
+        (
+            df_test,
+            received_ID_col_test,
+            received_single_time_series_test,
+            received_dict_test,
+            _,
+        ) = df_utils.prep_or_copy_df(df_test)
+        df_test_new = pd.DataFrame()
+        for df_name, df_test_i in df_test.groupby("ID"):
+            df_train_i = df_train[df_train["ID"] == df_name].copy(deep=True)
+            df_test_i = pd.concat([df_train_i.tail(self.season_length), df_test_i], ignore_index=True)
+            df_test_new = pd.concat((df_test_new, df_test_i), ignore_index=True)
+        df_test = df_utils.return_df_in_original_format(
+            df_test_new, received_ID_col_test, received_single_time_series_test, received_dict_test
+        )
         return df_test
 
     def maybe_drop_first_forecasts(self, predicted, df):
         """
-        Removes first K values from predicted and df that have been previously added.
+        Removes first season_length values from predicted and df that have been previously added.
 
         Parameters
         ----------
@@ -387,11 +394,11 @@ class SeasonalNaiveModel(Model):
         Returns
         -------
             pd.DataFrame
-                dataframe containing predicted data reduced by the first K values.
+                dataframe containing predicted data reduced by the first season_length values.
             pd.DataFrame
-                dataframe containing initial data reduced by the first K values.
+                dataframe containing initial data reduced by the first season_length values.
         """
-        if self.K > 0:
+        if self.season_length > 0:
             (
                 predicted,
                 received_ID_col_pred,
@@ -406,8 +413,8 @@ class SeasonalNaiveModel(Model):
             df_new = pd.DataFrame()
             for df_name, df_i in df.groupby("ID"):
                 predicted_i = predicted[predicted["ID"] == df_name].copy(deep=True)
-                predicted_i = predicted_i[self.K :]
-                df_i = df_i[self.K :]
+                predicted_i = predicted_i[self.season_length :]
+                df_i = df_i[self.season_length :]
                 df_new = pd.concat((df_new, df_i), ignore_index=True)
                 predicted_new = pd.concat((predicted_new, predicted_i), ignore_index=True)
             df = df_utils.return_df_in_original_format(
@@ -416,52 +423,6 @@ class SeasonalNaiveModel(Model):
             predicted = df_utils.return_df_in_original_format(
                 predicted_new, received_ID_col_pred, received_single_time_series_pred, received_dict_test_pred
             )
-        return predicted, df
-
-    def maybe_drop_added_dates(self, predicted, df):
-        """if Model imputed any dates: removes any dates in predicted which are not in df_test.
-
-        Parameters
-        ----------
-            predicted: pd.DataFrame
-                dataframe containing predicted data
-            df: pd.DataFrame
-                dataframe containing initial data
-
-        Returns
-        -------
-            pd.DataFrame
-                dataframe containing predicted data of dates that are present in df.
-            pd.DataFrame
-                dataframe containing initial data.
-        """
-        (
-            predicted,
-            received_ID_col_pred,
-            received_single_time_series_pred,
-            received_dict_test_pred,
-            _,
-        ) = df_utils.prep_or_copy_df(predicted)
-        df, received_ID_col_df, received_single_time_series_df, received_dict_test_df, _ = df_utils.prep_or_copy_df(df)
-        predicted_new = pd.DataFrame()
-        df_new = pd.DataFrame()
-        for df_name, df_i in df.groupby("ID"):
-            predicted_i = predicted[predicted["ID"] == df_name].copy(deep=True)
-            predicted_i["ds"] = convert_to_datetime(predicted_i["ds"])
-            df_i["ds"] = convert_to_datetime(df_i["ds"])
-            df_i.set_index("ds", inplace=True)
-            predicted_i.set_index("ds", inplace=True)
-            predicted_i = predicted_i.loc[df_i.index]
-            predicted_i = predicted_i.reset_index()
-            df_i = df_i.reset_index()
-            df_new = pd.concat((df_new, df_i), ignore_index=True)
-            predicted_new = pd.concat((predicted_new, predicted_i), ignore_index=True)
-        df = df_utils.return_df_in_original_format(
-            df_new, received_ID_col_df, received_single_time_series_df, received_dict_test_df
-        )
-        predicted = df_utils.return_df_in_original_format(
-            predicted_new, received_ID_col_pred, received_single_time_series_pred, received_dict_test_pred
-        )
         return predicted, df
 
     def _predict_raw(self, df):
@@ -485,48 +446,12 @@ class SeasonalNaiveModel(Model):
         # Receives df with single ID column
         assert len(df["ID"].unique()) == 1
 
-        dates = df["ds"].iloc[self.K : -self.n_forecasts + 1].reset_index(drop=True)
-        # assemble last values based on K
-        last_k_vals_arrays = [df["y"].iloc[i : i + self.K].values for i in range(0, dates.shape[0])]
+        dates = df["ds"].iloc[self.season_length : -self.n_forecasts + 1].reset_index(drop=True)
+        # assemble last values based on season_length
+        last_k_vals_arrays = [df["y"].iloc[i : i + self.season_length].values for i in range(0, dates.shape[0])]
         last_k_vals = np.stack(last_k_vals_arrays, axis=0)
         # Compute the predictions
-        predicted = np.array([last_k_vals[:, i % self.K] for i in range(self.n_forecasts)]).T
+        predicted = np.array([last_k_vals[:, i % self.season_length] for i in range(self.n_forecasts)]).T
 
         # No un-scaling and un-normalization needed. Operations not applicable for naive model
         return dates, predicted
-
-    def _reshape_raw_predictions_to_forecst_df(self, df_i, predicted):  # Todo outsource to df_utils?
-        """Turns forecast-origin-wise predictions into forecast-target-wise predictions.
-
-        Parameters
-        ----------
-            df : pd.DataFrame
-                input dataframe
-            predicted : np.array
-                Array containing the predictions
-
-        Returns
-        -------
-            pd.DataFrame
-                columns ``ds``, ``y``, optionally ``ID`` and [``yhat<i>``],
-
-                Note
-                ----
-                where yhat<i> refers to the i-step-ahead prediction for this row's datetime.
-                e.g. yhat3 is the prediction for this datetime, predicted 3 steps ago, "3 steps old".
-        """
-        cols = ["ds", "y", "ID"]  # cols to keep from df
-        fcst_df = pd.concat((df_i[cols],), axis=1)
-        # create a line for each forecast_lag
-        # 'yhat<i>' is the forecast for 'y' at 'ds' from i steps ago.
-        for forecast_lag in range(1, self.n_forecasts + 1):
-            forecast = predicted[:, forecast_lag - 1]
-            pad_before = self.K + forecast_lag - 1
-            pad_after = self.n_forecasts - forecast_lag
-            yhat = np.concatenate(
-                ([np.NaN] * pad_before, forecast, [np.NaN] * pad_after)
-            )  # add pad based on n_forecasts and current forecast_lag
-            name = f"yhat{forecast_lag}"
-            fcst_df[name] = yhat
-
-        return fcst_df

--- a/tot/models.py
+++ b/tot/models.py
@@ -1,13 +1,14 @@
 import logging
-import numpy as np
-from copy import copy, deepcopy
 from abc import ABC, abstractmethod
+from copy import copy, deepcopy
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple, Type
 
+import numpy as np
 import pandas as pd
 from neuralprophet import NeuralProphet, df_utils
-from tot.utils import convert_to_datetime, _get_seasons
+
+from tot.utils import _get_seasons, convert_to_datetime
 
 try:
     from prophet import Prophet
@@ -89,6 +90,7 @@ class ProphetModel(Model):
                 self.model.add_seasonality(name="{}_daily".format(str(seasonality)), period=seasonality)
         self.n_forecasts = 1
         self.n_lags = 0
+        self.K = None
 
     def fit(self, df: pd.DataFrame, freq: str):
         if "ID" in df.columns and len(df["ID"].unique()) > 1:
@@ -125,6 +127,7 @@ class NeuralProphetModel(Model):
                 self.model.add_seasonality(name="{}_daily".format(str(seasonality)), period=seasonality)
         self.n_forecasts = self.model.n_forecasts
         self.n_lags = self.model.n_lags
+        self.K = None
 
     def fit(self, df: pd.DataFrame, freq: str):
         self.freq = freq


### PR DESCRIPTION
Implement seasonal naive model from scratch.

**Key Changes**
- is implement as parent class for NaiveModel
- no fitting procedure necessary for naive models. Consequently, no `model_class = None `and` self.model` not assigned. However, assign relevant information in` fit()`.
- adhere to applicable `predict() `procedure of neuralprophet, i.e. adopt and adapt `df_utils.prep_or_copy_df()`,  `_predict_raw()`, `_reshape_raw_predictions_to_forecst_df()`, and `df_utils.return_df_in_original_format()`.
- implement `predict()` to return df with target-wise predictions
- no raw data support in `predict()`

**Model capabilities**
- univariate time series, df with single ID
- custom season K
- n_forecasts>=1
- n_lags = None


**Further open requirements**
- [ ]  potentially consider multi-ID df for multi-target forecast
- [ ]  implement frequency check yet
- [ ]  implement frequency conversion
- [x]  make predict() more generic, i.e. implement df_utils.prep_or_copy_df(df) and df_utils.return_df_in_original_format(forecast, received_ID_col, received_single_time_series)
- [x]  apend test_df with required number of past observations
- [x] restructure to avoid duplicate code with naive model --> NaiveModel implemented as child class

**Review Checklist**
- [x]  I have performed a self-review of my own code.
- [x]  I have commented my code, added Docstrings and data types to function definitions.
- [x]  I have added model class Docstring 
- [x]  I have added pytests to check whether my feature / fix works and assertations are called (checked **with/ without ID** column)