### PR TITLE
add random seed on experiment level

### DIFF
--- a/tot/experiment.py
+++ b/tot/experiment.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 
 import numpy as np
 import pandas as pd
-from neuralprophet import df_utils
+from neuralprophet import df_utils, set_random_seed
 
 from tot.dataset import Dataset
 from tot.metrics import ERROR_FUNCTIONS
@@ -157,6 +157,7 @@ class SimpleExperiment(Experiment):
     """
 
     def run(self):
+        set_random_seed(42)
         model = self.model_class(self.params)
         df = model._handle_missing_data(self.data.df, freq=self.data.freq, predicting=False)
         df_train, df_test = df_utils.split_df(
@@ -195,8 +196,11 @@ class CrossValidationExperiment(Experiment):
     # results_cv_test: dict = field(init=False)
 
     def _run_fold(self, args):
+        set_random_seed(42)
         df_train, df_test, current_fold = args
         model = self.model_class(self.params)
+        df_train = model._handle_missing_data(df_train, freq=self.data.freq, predicting=False)
+        df_test = model._handle_missing_data(df_test, freq=self.data.freq, predicting=False)
         model.fit(df=df_train, freq=self.data.freq)
         result_train, result_test = self._evaluate_model(model, df_train, df_test, current_fold=current_fold)
         del model


### PR DESCRIPTION
🔬 Background
When comparing multiple models and executing a benchmark, we would like to ensure comparability. Hence, we set a random seed to a fixed value.

🔮 Key changes
Implement  `set_random_seed()` method that sets a random seed for torch models.
📋 Review Checklist
- [x] I have performed a self-review of my own code.
- [x]  I have commented my code, added docstrings and data types to function definitions.
- [x]  I have implemented pytests if necessary