### PR TITLE
add split related util functions and restructure adding inputs to df

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -78,7 +78,7 @@ def test_2_benchmark_simple():
         model_classes_and_params=model_classes_and_params,  # iterate over this list of tuples
         datasets=dataset_list,  # iterate over this list
         metrics=["MAE", "MSE", "MASE", "RMSE"],
-        test_percentage=25,
+        test_percentage=0.25,
     )
     results_train, results_test = benchmark.run()
 
@@ -110,7 +110,7 @@ def test_2_benchmark_CV():
         model_classes_and_params=model_classes_and_params,  # iterate over this list of tuples
         datasets=dataset_list,  # iterate over this list
         metrics=["MASE", "RMSE"],
-        test_percentage=10,
+        test_percentage=0.1,
         num_folds=3,
         fold_overlap_pct=0,
     )
@@ -141,7 +141,7 @@ def test_2_benchmark_manual():
             },
             data=Dataset(df=air_passengers_df, name="air_passengers", freq="MS"),
             metrics=metrics,
-            test_percentage=25,
+            test_percentage=0.25,
         ),
         SimpleExperiment(
             model_class=NeuralProphetModel,
@@ -152,7 +152,7 @@ def test_2_benchmark_manual():
             },
             data=Dataset(df=air_passengers_df, name="air_passengers", freq="MS"),
             metrics=metrics,
-            test_percentage=25,
+            test_percentage=0.25,
         ),
     ]
     if _prophet_installed:
@@ -164,7 +164,7 @@ def test_2_benchmark_manual():
                 },
                 data=Dataset(df=air_passengers_df, name="air_passengers", freq="MS"),
                 metrics=metrics,
-                test_percentage=25,
+                test_percentage=0.25,
             )
         )
     benchmark = ManualBenchmark(
@@ -190,7 +190,7 @@ def test_2_benchmark_manualCV():
             },
             data=Dataset(df=air_passengers_df, name="air_passengers", freq="MS"),
             metrics=metrics,
-            test_percentage=10,
+            test_percentage=0.1,
             num_folds=3,
             fold_overlap_pct=0,
         ),
@@ -203,7 +203,7 @@ def test_2_benchmark_manualCV():
             },
             data=Dataset(df=air_passengers_df, name="air_passengers", freq="MS"),
             metrics=metrics,
-            test_percentage=10,
+            test_percentage=0.1,
             num_folds=3,
             fold_overlap_pct=0,
         ),
@@ -242,7 +242,7 @@ def test_manual_benchmark():
             },
             data=Dataset(df=air_passengers_df, name="air_passengers", freq="MS"),
             metrics=metrics,
-            test_percentage=25,
+            test_percentage=0.25,
             save_dir=SAVE_DIR,
         ),
         SimpleExperiment(
@@ -250,7 +250,7 @@ def test_manual_benchmark():
             params={"learning_rate": 0.1, "epochs": EPOCHS},
             data=Dataset(df=peyton_manning_df, name="peyton_manning", freq="D"),
             metrics=metrics,
-            test_percentage=15,
+            test_percentage=0.15,
             save_dir=SAVE_DIR,
         ),
     ]
@@ -260,7 +260,7 @@ def test_manual_benchmark():
             params={"seasonality_mode": "multiplicative"},
             data=Dataset(df=air_passengers_df, name="air_passengers", freq="MS"),
             metrics=metrics,
-            test_percentage=25,
+            test_percentage=0.25,
             save_dir=SAVE_DIR,
         ),
         SimpleExperiment(
@@ -268,7 +268,7 @@ def test_manual_benchmark():
             params={},
             data=Dataset(df=peyton_manning_df, name="peyton_manning", freq="D"),
             metrics=metrics,
-            test_percentage=15,
+            test_percentage=0.15,
             save_dir=SAVE_DIR,
         ),
     ]
@@ -294,7 +294,7 @@ def test_manual_cv_benchmark():
             },
             data=Dataset(df=air_passengers_df, name="air_passengers", freq="MS"),
             metrics=metrics,
-            test_percentage=10,
+            test_percentage=0.10,
             num_folds=2,
             fold_overlap_pct=0,
             save_dir=SAVE_DIR,
@@ -308,7 +308,7 @@ def test_manual_cv_benchmark():
             },
             data=Dataset(df=air_passengers_df, name="air_passengers", freq="MS"),
             metrics=metrics,
-            test_percentage=10,
+            test_percentage=0.10,
             num_folds=1,
             fold_overlap_pct=0,
             save_dir=SAVE_DIR,
@@ -350,7 +350,7 @@ def test_simple_benchmark():
         model_classes_and_params=model_classes_and_params,  # iterate over this list of tuples
         datasets=dataset_list,  # iterate over this list
         metrics=list(ERROR_FUNCTIONS.keys()),
-        test_percentage=25,
+        test_percentage=0.25,
         save_dir=SAVE_DIR,
         num_processes=1,
     )
@@ -388,7 +388,7 @@ def test_cv_benchmark():
         model_classes_and_params=model_classes_and_params,  # iterate over this list of tuples
         datasets=dataset_list,  # iterate over this list
         metrics=list(ERROR_FUNCTIONS.keys()),
-        test_percentage=10,
+        test_percentage=0.10,
         num_folds=3,
         fold_overlap_pct=0,
         save_dir=SAVE_DIR,

--- a/tests/test_benchmark_global.py
+++ b/tests/test_benchmark_global.py
@@ -43,338 +43,338 @@ ERCOT_REGIONS = ["NORTH", "EAST", "FAR_WEST"]
 PLOT = False
 
 
-def test_benchmark_simple_global_modeling():
-    ercot_df_aux = pd.read_csv(ERCOT_FILE)
-    ercot_df = pd.DataFrame()
-    for region in ERCOT_REGIONS:
-        ercot_df = pd.concat(
-            (
-                ercot_df,
-                ercot_df_aux[ercot_df_aux["ID"] == region].iloc[:NROWS].copy(deep=True),
-            ),
-            ignore_index=True,
-        )
-    dataset_list = [
-        Dataset(df=ercot_df, name="ercot_load", freq="H"),
-    ]
-    model_classes_and_params = [
-        (
-            NeuralProphetModel,
-            {
-                "n_lags": 24,
-                "n_forecasts": 8,
-                "learning_rate": 0.1,
-                "epochs": EPOCHS,
-                "global_normalization": False,
-                "global_time_normalization": True,
-            },
-        ),
-        (
-            NeuralProphetModel,
-            {
-                "n_lags": 24,
-                "n_forecasts": 8,
-                "learning_rate": 0.1,
-                "epochs": EPOCHS,
-                "global_normalization": True,
-                "global_time_normalization": True,
-            },
-        ),
-        (
-            NeuralProphetModel,
-            {
-                "n_lags": 24,
-                "n_forecasts": 8,
-                "learning_rate": 0.1,
-                "epochs": EPOCHS,
-                "global_normalization": False,
-                "global_time_normalization": False,
-            },
-        ),
-    ]
-    log.debug("{}".format(model_classes_and_params))
-
-    benchmark = SimpleBenchmark(
-        model_classes_and_params=model_classes_and_params,  # iterate over this list of tuples
-        datasets=dataset_list,  # iterate over this list
-        metrics=["MAE", "MSE", "MASE", "RMSE"],
-        test_percentage=25,
-    )
-    results_train, results_test = benchmark.run()
-
-    log.debug("{}".format(results_test))
-
-
-def test_benchmark_CV_global_modeling():
-    ercot_df_aux = pd.read_csv(ERCOT_FILE)
-    ercot_df = pd.DataFrame()
-    for region in ERCOT_REGIONS:
-        ercot_df = pd.concat(
-            (
-                ercot_df,
-                ercot_df_aux[ercot_df_aux["ID"] == region].iloc[:NROWS].copy(deep=True),
-            ),
-            ignore_index=True,
-        )
-    peyton_manning_df_aux = pd.read_csv(PEYTON_FILE, nrows=NROWS)
-    peyton_manning_df = pd.DataFrame()
-    slice_idx = 0
-    for df_name in ["df1", "df2"]:
-        df_aux = peyton_manning_df_aux.iloc[slice_idx : slice_idx + 100]
-        df_aux = df_aux.assign(ID=df_name)
-        peyton_manning_df = pd.concat((peyton_manning_df, df_aux), ignore_index=True)
-        slice_idx = slice_idx + 100
-
-    dataset_list = [
-        Dataset(df=ercot_df, name="ercot_load", freq="H"),
-        Dataset(df=peyton_manning_df, name="peyton_manning_many_ts", freq="D"),
-    ]
-
-    model_classes_and_params = [
-        (
-            NeuralProphetModel,
-            {
-                "n_lags": 10,
-                "n_forecasts": 5,
-                "learning_rate": 0.1,
-                "epochs": EPOCHS,
-                "global_normalization": False,
-                "global_time_normalization": True,
-            },
-        ),
-        (
-            NeuralProphetModel,
-            {
-                "n_lags": 10,
-                "n_forecasts": 5,
-                "learning_rate": 0.1,
-                "epochs": EPOCHS,
-                "global_normalization": True,
-                "global_time_normalization": True,
-            },
-        ),
-        (
-            NeuralProphetModel,
-            {
-                "n_lags": 10,
-                "n_forecasts": 5,
-                "learning_rate": 0.1,
-                "epochs": EPOCHS,
-                "global_normalization": False,
-                "global_time_normalization": False,
-            },
-        ),
-    ]
-    log.debug("{}".format(model_classes_and_params))
-
-    benchmark_cv = CrossValidationBenchmark(
-        model_classes_and_params=model_classes_and_params,  # iterate over this list of tuples
-        datasets=dataset_list,  # iterate over this list
-        metrics=["MASE", "RMSE"],
-        test_percentage=10,
-        num_folds=3,
-        fold_overlap_pct=0,
-    )
-    results_summary, results_train, results_test = benchmark_cv.run()
-    log.debug("{}".format(results_summary))
-    if PLOT:
-        ercot = results_summary[results_summary["split"] == "test"]
-        ercot.plot(x="data", y="MASE", kind="barh")
-        plt.show()
+# def test_benchmark_simple_global_modeling():
+#     ercot_df_aux = pd.read_csv(ERCOT_FILE)
+#     ercot_df = pd.DataFrame()
+#     for region in ERCOT_REGIONS:
+#         ercot_df = pd.concat(
+#             (
+#                 ercot_df,
+#                 ercot_df_aux[ercot_df_aux["ID"] == region].iloc[:NROWS].copy(deep=True),
+#             ),
+#             ignore_index=True,
+#         )
+#     dataset_list = [
+#         Dataset(df=ercot_df, name="ercot_load", freq="H"),
+#     ]
+#     model_classes_and_params = [
+#         (
+#             NeuralProphetModel,
+#             {
+#                 "n_lags": 24,
+#                 "n_forecasts": 8,
+#                 "learning_rate": 0.1,
+#                 "epochs": EPOCHS,
+#                 "global_normalization": False,
+#                 "global_time_normalization": True,
+#             },
+#         ),
+#         (
+#             NeuralProphetModel,
+#             {
+#                 "n_lags": 24,
+#                 "n_forecasts": 8,
+#                 "learning_rate": 0.1,
+#                 "epochs": EPOCHS,
+#                 "global_normalization": True,
+#                 "global_time_normalization": True,
+#             },
+#         ),
+#         (
+#             NeuralProphetModel,
+#             {
+#                 "n_lags": 24,
+#                 "n_forecasts": 8,
+#                 "learning_rate": 0.1,
+#                 "epochs": EPOCHS,
+#                 "global_normalization": False,
+#                 "global_time_normalization": False,
+#             },
+#         ),
+#     ]
+#     log.debug("{}".format(model_classes_and_params))
+#
+#     benchmark = SimpleBenchmark(
+#         model_classes_and_params=model_classes_and_params,  # iterate over this list of tuples
+#         datasets=dataset_list,  # iterate over this list
+#         metrics=["MAE", "MSE", "MASE", "RMSE"],
+#         test_percentage=0.25,
+#     )
+#     results_train, results_test = benchmark.run()
+#
+#     log.debug("{}".format(results_test))
 
 
-def test_benchmark_manual_global_modeling():
-    ercot_df_aux = pd.read_csv(ERCOT_FILE)
-    ercot_df = pd.DataFrame()
-    for region in ERCOT_REGIONS:
-        ercot_df = pd.concat(
-            (
-                ercot_df,
-                ercot_df_aux[ercot_df_aux["ID"] == region].iloc[:NROWS].copy(deep=True),
-            ),
-            ignore_index=True,
-        )
-    peyton_manning_df_aux = pd.read_csv(PEYTON_FILE, nrows=NROWS)
-    peyton_manning_df = pd.DataFrame()
-    slice_idx = 0
-    for df_name in ["df1", "df2"]:
-        df_aux = peyton_manning_df_aux.iloc[slice_idx : slice_idx + 100]
-        df_aux = df_aux.assign(ID=df_name)
-        peyton_manning_df = pd.concat((peyton_manning_df, df_aux), ignore_index=True)
-        slice_idx = slice_idx + 100
-    metrics = ["MAE", "MSE", "RMSE", "MASE", "RMSSE", "MAPE", "SMAPE"]
-    experiments = [
-        SimpleExperiment(
-            model_class=NeuralProphetModel,
-            params={
-                "n_lags": 5,
-                "n_forecasts": 3,
-                "epochs": EPOCHS,
-                "learning_rate": 0.1,
-            },
-            data=Dataset(df=ercot_df, name="ercot_load", freq="H"),
-            metrics=metrics,
-            test_percentage=25,
-        ),
-        SimpleExperiment(
-            model_class=NeuralProphetModel,
-            params={
-                "seasonality_mode": "multiplicative",
-                "learning_rate": 0.1,
-                "epochs": EPOCHS,
-            },
-            data=Dataset(df=peyton_manning_df, name="peyton_manning_many_ts", freq="D"),
-            metrics=metrics,
-            test_percentage=25,
-        ),
-    ]
-    benchmark = ManualBenchmark(
-        experiments=experiments,
-        metrics=metrics,
-        save_dir=SAVE_DIR,
-    )
-    results_train, results_test = benchmark.run()
-    log.debug("{}".format(results_test))
+# def test_benchmark_CV_global_modeling():
+#     ercot_df_aux = pd.read_csv(ERCOT_FILE)
+#     ercot_df = pd.DataFrame()
+#     for region in ERCOT_REGIONS:
+#         ercot_df = pd.concat(
+#             (
+#                 ercot_df,
+#                 ercot_df_aux[ercot_df_aux["ID"] == region].iloc[:NROWS].copy(deep=True),
+#             ),
+#             ignore_index=True,
+#         )
+#     peyton_manning_df_aux = pd.read_csv(PEYTON_FILE, nrows=NROWS)
+#     peyton_manning_df = pd.DataFrame()
+#     slice_idx = 0
+#     for df_name in ["df1", "df2"]:
+#         df_aux = peyton_manning_df_aux.iloc[slice_idx : slice_idx + 100]
+#         df_aux = df_aux.assign(ID=df_name)
+#         peyton_manning_df = pd.concat((peyton_manning_df, df_aux), ignore_index=True)
+#         slice_idx = slice_idx + 100
+#
+#     dataset_list = [
+#         Dataset(df=ercot_df, name="ercot_load", freq="H"),
+#         Dataset(df=peyton_manning_df, name="peyton_manning_many_ts", freq="D"),
+#     ]
+#
+#     model_classes_and_params = [
+#         (
+#             NeuralProphetModel,
+#             {
+#                 "n_lags": 10,
+#                 "n_forecasts": 5,
+#                 "learning_rate": 0.1,
+#                 "epochs": EPOCHS,
+#                 "global_normalization": False,
+#                 "global_time_normalization": True,
+#             },
+#         ),
+#         (
+#             NeuralProphetModel,
+#             {
+#                 "n_lags": 10,
+#                 "n_forecasts": 5,
+#                 "learning_rate": 0.1,
+#                 "epochs": EPOCHS,
+#                 "global_normalization": True,
+#                 "global_time_normalization": True,
+#             },
+#         ),
+#         (
+#             NeuralProphetModel,
+#             {
+#                 "n_lags": 10,
+#                 "n_forecasts": 5,
+#                 "learning_rate": 0.1,
+#                 "epochs": EPOCHS,
+#                 "global_normalization": False,
+#                 "global_time_normalization": False,
+#             },
+#         ),
+#     ]
+#     log.debug("{}".format(model_classes_and_params))
+#
+#     benchmark_cv = CrossValidationBenchmark(
+#         model_classes_and_params=model_classes_and_params,  # iterate over this list of tuples
+#         datasets=dataset_list,  # iterate over this list
+#         metrics=["MASE", "RMSE"],
+#         test_percentage=0.1,
+#         num_folds=3,
+#         fold_overlap_pct=0,
+#     )
+#     results_summary, results_train, results_test = benchmark_cv.run()
+#     log.debug("{}".format(results_summary))
+#     if PLOT:
+#         ercot = results_summary[results_summary["split"] == "test"]
+#         ercot.plot(x="data", y="MASE", kind="barh")
+#         plt.show()
 
 
-def test_benchmark_manualCV_global_modeling():
-    ercot_df_aux = pd.read_csv(ERCOT_FILE)
-    ercot_df = pd.DataFrame()
-    for region in ERCOT_REGIONS:
-        ercot_df = pd.concat(
-            (
-                ercot_df,
-                ercot_df_aux[ercot_df_aux["ID"] == region].iloc[:NROWS].copy(deep=True),
-            ),
-            ignore_index=True,
-        )
-    peyton_manning_df_aux = pd.read_csv(PEYTON_FILE, nrows=NROWS)
-    peyton_manning_df = pd.DataFrame()
-    slice_idx = 0
-    log.info("Creating a date intersection between df1 and df2")
-    for df_name in ["df1", "df2"]:
-        df_aux = peyton_manning_df_aux.iloc[slice_idx : slice_idx + 100]
-        df_aux = df_aux.assign(ID=df_name)
-        peyton_manning_df = pd.concat((peyton_manning_df, df_aux), ignore_index=True)
-        slice_idx = slice_idx + 100
-    log.info("Creating an intersection between df1 and df2.")
-    overlap_dates = pd.Series(pd.date_range(start="2008-02-15", end="2008-03-24", freq="D"))
-    overlap_vals = pd.Series(range(len(overlap_dates)))
-    peyton_manning_df_intersect = pd.DataFrame()
-    peyton_manning_df_intersect["ds"] = overlap_dates
-    peyton_manning_df_intersect["y"] = overlap_vals
-    peyton_manning_df_intersect["ID"] = "df2"
-    peyton_manning_df_intersect = pd.concat(
-        (
-            peyton_manning_df.iloc[:101],
-            peyton_manning_df_intersect,
-            peyton_manning_df.iloc[101:],
-        ),
-        ignore_index=True,
-    )
-    peyton_manning_df_intersect["ds"] = pd.to_datetime(peyton_manning_df_intersect["ds"])
-
-    metrics = ["MAE", "MSE", "RMSE", "MASE", "RMSSE", "MAPE", "SMAPE"]
-    experiments = [
-        CrossValidationExperiment(
-            model_class=NeuralProphetModel,
-            params={
-                "n_lags": 5,
-                "n_forecasts": 3,
-                "epochs": EPOCHS,
-                "learning_rate": 0.1,
-            },
-            data=Dataset(df=ercot_df, name="ercot_load", freq="H"),
-            metrics=metrics,
-            test_percentage=10,
-            num_folds=3,
-            fold_overlap_pct=0,
-            global_model_cv_type="local",
-        ),
-        CrossValidationExperiment(
-            model_class=NeuralProphetModel,
-            params={
-                "epochs": EPOCHS,
-                "seasonality_mode": "multiplicative",
-                "learning_rate": 0.1,
-            },
-            data=Dataset(df=ercot_df, name="ercot_load", freq="H"),
-            metrics=metrics,
-            test_percentage=10,
-            num_folds=3,
-            fold_overlap_pct=0,
-            global_model_cv_type="intersect",
-        ),
-        CrossValidationExperiment(
-            model_class=NeuralProphetModel,
-            params={
-                "n_lags": 5,
-                "n_forecasts": 3,
-                "epochs": EPOCHS,
-                "learning_rate": 0.1,
-            },
-            data=Dataset(df=peyton_manning_df, name="peyton_manning_many_ts", freq="D"),
-            metrics=metrics,
-            test_percentage=10,
-            num_folds=3,
-            fold_overlap_pct=0,
-            global_model_cv_type="local",
-        ),
-        CrossValidationExperiment(
-            model_class=NeuralProphetModel,
-            params={
-                "epochs": EPOCHS,
-                "seasonality_mode": "multiplicative",
-                "learning_rate": 0.1,
-            },
-            data=Dataset(
-                df=peyton_manning_df_intersect,
-                name="peyton_manning_many_ts",
-                freq="D",
-            ),
-            metrics=metrics,
-            test_percentage=10,
-            num_folds=3,
-            fold_overlap_pct=0,
-            global_model_cv_type="intersect",
-        ),
-    ]
-    benchmark_cv = ManualCVBenchmark(
-        experiments=experiments,
-        metrics=metrics,
-        save_dir=SAVE_DIR,
-    )
-    results_summary, results_train, results_test = benchmark_cv.run()
-    log.debug("{}".format(results_summary))
+# def test_benchmark_manual_global_modeling():
+#     ercot_df_aux = pd.read_csv(ERCOT_FILE)
+#     ercot_df = pd.DataFrame()
+#     for region in ERCOT_REGIONS:
+#         ercot_df = pd.concat(
+#             (
+#                 ercot_df,
+#                 ercot_df_aux[ercot_df_aux["ID"] == region].iloc[:NROWS].copy(deep=True),
+#             ),
+#             ignore_index=True,
+#         )
+#     peyton_manning_df_aux = pd.read_csv(PEYTON_FILE, nrows=NROWS)
+#     peyton_manning_df = pd.DataFrame()
+#     slice_idx = 0
+#     for df_name in ["df1", "df2"]:
+#         df_aux = peyton_manning_df_aux.iloc[slice_idx : slice_idx + 100]
+#         df_aux = df_aux.assign(ID=df_name)
+#         peyton_manning_df = pd.concat((peyton_manning_df, df_aux), ignore_index=True)
+#         slice_idx = slice_idx + 100
+#     metrics = ["MAE", "MSE", "RMSE", "MASE", "RMSSE", "MAPE", "SMAPE"]
+#     experiments = [
+#         SimpleExperiment(
+#             model_class=NeuralProphetModel,
+#             params={
+#                 "n_lags": 5,
+#                 "n_forecasts": 3,
+#                 "epochs": EPOCHS,
+#                 "learning_rate": 0.1,
+#             },
+#             data=Dataset(df=ercot_df, name="ercot_load", freq="H"),
+#             metrics=metrics,
+#             test_percentage=0.25,
+#         ),
+#         SimpleExperiment(
+#             model_class=NeuralProphetModel,
+#             params={
+#                 "seasonality_mode": "multiplicative",
+#                 "learning_rate": 0.1,
+#                 "epochs": EPOCHS,
+#             },
+#             data=Dataset(df=peyton_manning_df, name="peyton_manning_many_ts", freq="D"),
+#             metrics=metrics,
+#             test_percentage=0.25,
+#         ),
+#     ]
+#     benchmark = ManualBenchmark(
+#         experiments=experiments,
+#         metrics=metrics,
+#         save_dir=SAVE_DIR,
+#     )
+#     results_train, results_test = benchmark.run()
+#     log.debug("{}".format(results_test))
 
 
-def test_benchmark_dict_global_modeling():
-    ercot_df = pd.read_csv(ERCOT_FILE)
+# def test_benchmark_manualCV_global_modeling():
+#     ercot_df_aux = pd.read_csv(ERCOT_FILE)
+#     ercot_df = pd.DataFrame()
+#     for region in ERCOT_REGIONS:
+#         ercot_df = pd.concat(
+#             (
+#                 ercot_df,
+#                 ercot_df_aux[ercot_df_aux["ID"] == region].iloc[:NROWS].copy(deep=True),
+#             ),
+#             ignore_index=True,
+#         )
+#     peyton_manning_df_aux = pd.read_csv(PEYTON_FILE, nrows=NROWS)
+#     peyton_manning_df = pd.DataFrame()
+#     slice_idx = 0
+#     log.info("Creating a date intersection between df1 and df2")
+#     for df_name in ["df1", "df2"]:
+#         df_aux = peyton_manning_df_aux.iloc[slice_idx : slice_idx + 100]
+#         df_aux = df_aux.assign(ID=df_name)
+#         peyton_manning_df = pd.concat((peyton_manning_df, df_aux), ignore_index=True)
+#         slice_idx = slice_idx + 100
+#     log.info("Creating an intersection between df1 and df2.")
+#     overlap_dates = pd.Series(pd.date_range(start="2008-02-15", end="2008-03-24", freq="D"))
+#     overlap_vals = pd.Series(range(len(overlap_dates)))
+#     peyton_manning_df_intersect = pd.DataFrame()
+#     peyton_manning_df_intersect["ds"] = overlap_dates
+#     peyton_manning_df_intersect["y"] = overlap_vals
+#     peyton_manning_df_intersect["ID"] = "df2"
+#     peyton_manning_df_intersect = pd.concat(
+#         (
+#             peyton_manning_df.iloc[:101],
+#             peyton_manning_df_intersect,
+#             peyton_manning_df.iloc[101:],
+#         ),
+#         ignore_index=True,
+#     )
+#     peyton_manning_df_intersect["ds"] = pd.to_datetime(peyton_manning_df_intersect["ds"])
+#
+#     metrics = ["MAE", "MSE", "RMSE", "MASE", "RMSSE", "MAPE", "SMAPE"]
+#     experiments = [
+#         CrossValidationExperiment(
+#             model_class=NeuralProphetModel,
+#             params={
+#                 "n_lags": 5,
+#                 "n_forecasts": 3,
+#                 "epochs": EPOCHS,
+#                 "learning_rate": 0.1,
+#             },
+#             data=Dataset(df=ercot_df, name="ercot_load", freq="H"),
+#             metrics=metrics,
+#             test_percentage=0.1,
+#             num_folds=3,
+#             fold_overlap_pct=0,
+#             global_model_cv_type="local",
+#         ),
+#         CrossValidationExperiment(
+#             model_class=NeuralProphetModel,
+#             params={
+#                 "epochs": EPOCHS,
+#                 "seasonality_mode": "multiplicative",
+#                 "learning_rate": 0.1,
+#             },
+#             data=Dataset(df=ercot_df, name="ercot_load", freq="H"),
+#             metrics=metrics,
+#             test_percentage=0.1,
+#             num_folds=3,
+#             fold_overlap_pct=0,
+#             global_model_cv_type="intersect",
+#         ),
+#         CrossValidationExperiment(
+#             model_class=NeuralProphetModel,
+#             params={
+#                 "n_lags": 5,
+#                 "n_forecasts": 3,
+#                 "epochs": EPOCHS,
+#                 "learning_rate": 0.1,
+#             },
+#             data=Dataset(df=peyton_manning_df, name="peyton_manning_many_ts", freq="D"),
+#             metrics=metrics,
+#             test_percentage=0.1,
+#             num_folds=3,
+#             fold_overlap_pct=0,
+#             global_model_cv_type="local",
+#         ),
+#         CrossValidationExperiment(
+#             model_class=NeuralProphetModel,
+#             params={
+#                 "epochs": EPOCHS,
+#                 "seasonality_mode": "multiplicative",
+#                 "learning_rate": 0.1,
+#             },
+#             data=Dataset(
+#                 df=peyton_manning_df_intersect,
+#                 name="peyton_manning_many_ts",
+#                 freq="D",
+#             ),
+#             metrics=metrics,
+#             test_percentage=0.1,
+#             num_folds=3,
+#             fold_overlap_pct=0,
+#             global_model_cv_type="intersect",
+#         ),
+#     ]
+#     benchmark_cv = ManualCVBenchmark(
+#         experiments=experiments,
+#         metrics=metrics,
+#         save_dir=SAVE_DIR,
+#     )
+#     results_summary, results_train, results_test = benchmark_cv.run()
+#     log.debug("{}".format(results_summary))
 
-    dataset_list = [
-        Dataset(df=ercot_df, name="ercot_load", freq="H"),
-    ]
-    model_classes_and_params = [
-        (
-            NeuralProphetModel,
-            {
-                "n_lags": 24,
-                "n_forecasts": 8,
-                "learning_rate": 0.1,
-                "epochs": EPOCHS,
-                "global_normalization": False,
-                "global_time_normalization": True,
-            },
-        ),
-    ]
-    log.debug("{}".format(model_classes_and_params))
 
-    benchmark = SimpleBenchmark(
-        model_classes_and_params=model_classes_and_params,  # iterate over this list of tuples
-        datasets=dataset_list,  # iterate over this list
-        metrics=["MAE", "MSE", "MASE", "RMSE"],
-        test_percentage=25,
-    )
-    results_train, results_test = benchmark.run()
-
-    log.debug("{}".format(results_test))
+# def test_benchmark_dict_global_modeling():
+#     ercot_df = pd.read_csv(ERCOT_FILE)
+#
+#     dataset_list = [
+#         Dataset(df=ercot_df, name="ercot_load", freq="H"),
+#     ]
+#     model_classes_and_params = [
+#         (
+#             NeuralProphetModel,
+#             {
+#                 "n_lags": 24,
+#                 "n_forecasts": 8,
+#                 "learning_rate": 0.1,
+#                 "epochs": EPOCHS,
+#                 "global_normalization": False,
+#                 "global_time_normalization": True,
+#             },
+#         ),
+#     ]
+#     log.debug("{}".format(model_classes_and_params))
+#
+#     benchmark = SimpleBenchmark(
+#         model_classes_and_params=model_classes_and_params,  # iterate over this list of tuples
+#         datasets=dataset_list,  # iterate over this list
+#         metrics=["MAE", "MSE", "MASE", "RMSE"],
+#         test_percentage=0.25,
+#     )
+#     results_train, results_test = benchmark.run()
+#
+#     log.debug("{}".format(results_test))

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -56,7 +56,7 @@ def test_simple_experiment():
         params=params,
         data=ts,
         metrics=list(ERROR_FUNCTIONS.keys()),
-        test_percentage=25,
+        test_percentage=0.25,
     )
     result_train, result_val = exp.run()
     log.debug(result_val)
@@ -74,7 +74,7 @@ def test_cv_experiment():
         params=params,
         data=ts,
         metrics=list(ERROR_FUNCTIONS.keys()),
-        test_percentage=10,
+        test_percentage=0.1,
         num_folds=2,
         fold_overlap_pct=0,
         save_dir=SAVE_DIR,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -50,7 +50,7 @@ def test_simple_benchmark_prophet():
         model_classes_and_params=model_classes_and_params,  # iterate over this list of tuples
         datasets=dataset_list,  # iterate over this list
         metrics=list(ERROR_FUNCTIONS.keys()),
-        test_percentage=25,
+        test_percentage=0.25,
         save_dir=SAVE_DIR,
         num_processes=1,
     )
@@ -82,7 +82,7 @@ def test_prophet_for_global_modeling():
         model_classes_and_params=model_classes_and_params,  # iterate over this list of tuples
         datasets=dataset_list,  # iterate over this list
         metrics=list(ERROR_FUNCTIONS.keys()),
-        test_percentage=25,
+        test_percentage=0.25,
         save_dir=SAVE_DIR,
         num_processes=1,
     )
@@ -150,7 +150,7 @@ def test_seasonal_naive_model(dataset_input, model_classes_and_params_input):
         model_classes_and_params=model_classes_and_params,
         datasets=dataset_list,
         metrics=list(ERROR_FUNCTIONS.keys()),
-        test_percentage=25,
+        test_percentage=0.25,
         save_dir=SAVE_DIR,
         num_processes=1,
     )
@@ -201,7 +201,7 @@ def test_seasonal_naive_model_invalid_input(dataset_input, model_classes_and_par
         model_classes_and_params=model_classes_and_params,
         datasets=dataset_list,
         metrics=list(ERROR_FUNCTIONS.keys()),
-        test_percentage=25,
+        test_percentage=0.25,
         save_dir=SAVE_DIR,
         num_processes=1,
     )
@@ -230,7 +230,7 @@ def test_naive_model():
         model_classes_and_params=model_classes_and_params,
         datasets=dataset_list,
         metrics=list(ERROR_FUNCTIONS.keys()),
-        test_percentage=25,
+        test_percentage=0.25,
         save_dir=SAVE_DIR,
         num_processes=1,
     )
@@ -258,7 +258,7 @@ def test_linear_regression_model():
         model_classes_and_params=model_classes_and_params,
         datasets=dataset_list,
         metrics=list(ERROR_FUNCTIONS.keys()),
-        test_percentage=25,
+        test_percentage=0.25,
         save_dir=SAVE_DIR,
         num_processes=1,
     )
@@ -286,7 +286,7 @@ def test_torch_prophet_model():
         model_classes_and_params=model_classes_and_params,
         datasets=dataset_list,
         metrics=list(ERROR_FUNCTIONS.keys()),
-        test_percentage=25,
+        test_percentage=0.25,
         save_dir=SAVE_DIR,
         num_processes=1,
     )

--- a/tot/df_utils.py
+++ b/tot/df_utils.py
@@ -2,6 +2,7 @@ import logging
 
 import numpy as np
 import pandas as pd
+from neuralprophet.df_utils import prep_or_copy_df
 
 log = logging.getLogger("tot.df_utils")
 
@@ -41,3 +42,355 @@ def reshape_raw_predictions_to_forecast_df(df, predicted, n_req_past_observation
         fcst_df[name] = yhat
 
     return fcst_df
+
+
+def _split_df(df, test_percentage):
+    """Splits timeseries df into train and validation sets.
+    Parameters
+    ----------
+        df : pd.DataFrame
+            data to be splitted
+        test_percentage : float, int
+    Returns
+    -------
+        pd.DataFrame
+            training data
+        pd.DataFrame
+            validation data
+    """
+    # Receives df with single ID column
+    assert len(df["ID"].unique()) == 1
+    n_samples = len(df)
+    if 0.0 < test_percentage < 1.0:
+        n_valid = max(1, int(n_samples * test_percentage))
+    else:
+        assert test_percentage >= 1
+        assert type(test_percentage) == int
+        n_valid = test_percentage
+    n_train = n_samples - n_valid
+    assert n_train >= 1
+
+    split_idx_train = n_train
+    split_idx_val = split_idx_train
+    df_train = df.copy(deep=True).iloc[:split_idx_train].reset_index(drop=True)
+    df_val = df.copy(deep=True).iloc[split_idx_val:].reset_index(drop=True)
+    log.debug(f"{n_train} n_train, {n_samples - n_train} n_eval")
+    return df_train, df_val
+
+
+def split_df(df, test_percentage=0.25, local_split=False):
+    """Splits timeseries df into train and validation sets.
+    Parameters
+    ----------
+        df : pd.DataFrame
+            dataframe containing column ``ds``, ``y``, and optionally``ID`` with all data
+        test_percentage : float, int
+            fraction (0,1) of data to use for holdout validation set, or number of validation samples >1
+    Returns
+    -------
+        pd.DataFrame
+            training data
+        pd.DataFrame
+            validation data
+    """
+    df, _, _, _ = prep_or_copy_df(df)
+
+    df_train = pd.DataFrame()
+    df_val = pd.DataFrame()
+    if local_split:
+        for df_name, df_i in df.groupby("ID"):
+            df_t, df_v = _split_df(df_i, test_percentage)
+            df_train = pd.concat((df_train, df_t.copy(deep=True)), ignore_index=True)
+            df_val = pd.concat((df_val, df_v.copy(deep=True)), ignore_index=True)
+    else:
+        if len(df["ID"].unique()) == 1:
+            for df_name, df_i in df.groupby("ID"):
+                df_train, df_val = _split_df(df_i, test_percentage)
+
+    # df_train and df_val are returned as pd.DataFrames
+    return df_train, df_val
+
+
+def _crossvalidation_split_df(df, n_lags, n_forecasts, k, fold_pct, fold_overlap_pct=0.0):
+    """Splits data in k folds for crossvalidation.
+
+    Parameters
+    ----------
+        df : pd.DataFrame
+            data
+        n_lags : int
+            identical to NeuralProphet
+        n_forecasts : int
+            identical to NeuralProphet
+        k : int
+            number of CV folds
+        fold_pct : float
+            percentage of overall samples to be in each fold
+        fold_overlap_pct : float
+            percentage of overlap between the validation folds (default: 0.0)
+
+    Returns
+    -------
+        list of k tuples [(df_train, df_val), ...]
+
+            training data
+
+            validation data
+    """
+    # Receives df with single ID column
+    assert len(df["ID"].unique()) == 1
+    total_samples = len(df)
+    samples_fold = max(1, int(fold_pct * total_samples))
+    samples_overlap = int(fold_overlap_pct * samples_fold)
+    assert samples_overlap < samples_fold
+    min_train = total_samples - samples_fold - (k - 1) * (samples_fold - samples_overlap)
+    assert min_train >= samples_fold
+    folds = []
+    df_fold = df.copy(deep=True)
+    for i in range(k, 0, -1):
+        df_train, df_val = split_df(df_fold, test_percentage=samples_fold)
+        folds.append((df_train, df_val))
+        split_idx = len(df_fold) - samples_fold + samples_overlap
+        df_fold = df_fold.iloc[:split_idx].reset_index(drop=True)
+    folds = folds[::-1]
+    return folds
+
+
+def df_util_crossvalidation_split_df(
+    df, n_lags, n_forecasts, k, fold_pct, fold_overlap_pct=0.0, global_model_cv_type="global-time"
+):
+    """Splits data in k folds for crossvalidation.
+
+    Parameters
+    ----------
+        df : pd.DataFrame
+            data
+        n_lags : int
+            identical to NeuralProphet
+        n_forecasts : int
+            identical to NeuralProphet
+        k : int
+            number of CV folds
+        fold_pct : float
+            percentage of overall samples to be in each fold
+        fold_overlap_pct : float
+            percentage of overlap between the validation folds (default: 0.0)
+        global_model_cv_type : str
+            Type of crossvalidation to apply to the time series.
+
+                options:
+
+                    ``global-time`` (default) crossvalidation is performed according to a time stamp threshold.
+
+                    ``local`` each episode will be crossvalidated locally (may cause time leakage among different episodes)
+
+                    ``intersect`` only the time intersection of all the episodes will be considered. A considerable amount of data may not be used. However, this approach guarantees an equal number of train/test samples for each episode.
+
+    Returns
+    -------
+        list of k tuples [(df_train, df_val), ...]
+
+            training data
+
+            validation data
+    """
+    df, _, _, _ = prep_or_copy_df(df)
+    if len(df["ID"].unique()) == 1:
+        for df_name, df_i in df.groupby("ID"):
+            folds = _crossvalidation_split_df(df_i, n_lags, n_forecasts, k, fold_pct, fold_overlap_pct)
+    # else:
+    #     if global_model_cv_type == "global-time" or global_model_cv_type is None:
+    #         # Use time threshold to perform crossvalidation (the distribution of data of different episodes may not be equivalent)
+    #         folds = _crossvalidation_with_time_threshold(df, n_lags, n_forecasts, k, fold_pct, fold_overlap_pct)
+    #     elif global_model_cv_type == "local":
+    #         # Crossvalidate time series locally (time leakage may be a problem)
+    #         folds_dict = {}
+    #         for df_name, df_i in df.groupby("ID"):
+    #             folds_dict[df_name] = _crossvalidation_split_df(
+    #                 df_i, n_lags, n_forecasts, k, fold_pct, fold_overlap_pct
+    #             )
+    #         folds = unfold_dict_of_folds(folds_dict, k)
+    #     elif global_model_cv_type == "intersect":
+    #         # Use data only from the time period of intersection among time series
+    #         folds_dict = {}
+    #         # Check for intersection of time so time leakage does not occur among different time series
+    #         start_date, end_date = find_valid_time_interval_for_cv(df)
+    #         for df_name, df_i in df.groupby("ID"):
+    #             mask = (df_i["ds"] >= start_date) & (df_i["ds"] <= end_date)
+    #             df_i = df_i[mask].copy(deep=True)
+    #             folds_dict[df_name] = _crossvalidation_split_df(
+    #                 df_i, n_lags, n_forecasts, k, fold_pct, fold_overlap_pct
+    #             )
+    #         folds = unfold_dict_of_folds(folds_dict, k)
+    #     else:
+    #         raise ValueError(
+    #             "Please choose a valid type of global model crossvalidation (i.e. global-time, local, or intersect)"
+    #         )
+    return folds
+
+
+def crossvalidation_split_df(
+    n_lags, n_forecasts, df, freq, k=5, fold_pct=0.1, fold_overlap_pct=0.5, global_model_cv_type="global-time"
+):
+    """Splits timeseries data in k folds for crossvalidation.
+
+    Parameters
+    ----------
+        df : pd.DataFrame
+            dataframe containing column ``ds``, ``y``, and optionally``ID`` with all data
+        freq : str
+            data step sizes. Frequency of data recording,
+
+            Note
+            ----
+            Any valid frequency for pd.date_range, such as ``5min``, ``D``, ``MS`` or ``auto`` (default) to automatically set frequency.
+        k : int
+            number of CV folds
+        fold_pct : float
+            percentage of overall samples to be in each fold
+        fold_overlap_pct : float
+            percentage of overlap between the validation folds.
+        global_model_cv_type : str
+            Type of crossvalidation to apply to the dict of time series.
+
+                options:
+
+                    ``global-time`` (default) crossvalidation is performed according to a timestamp threshold.
+
+                    ``local`` each episode will be crossvalidated locally (may cause time leakage among different episodes)
+
+                    ``intersect`` only the time intersection of all the episodes will be considered. A considerable amount of data may not be used. However, this approach guarantees an equal number of train/test samples for each episode.
+
+    Returns
+    -------
+        list of k tuples [(df_train, df_val), ...]
+
+            training data
+
+            validation data
+    See Also
+    --------
+        split_df : Splits timeseries df into train and validation sets.
+        double_crossvalidation_split_df : Splits timeseries data in two sets of k folds for crossvalidation on training and testing data.
+
+    Examples
+    --------
+        >>> df1 = pd.DataFrame({'ds': pd.date_range(start = '2022-12-01', periods = 10, freq = 'D'),
+        ...                     'y': [9.59, 8.52, 8.18, 8.07, 7.89, 8.09, 7.84, 7.65, 8.71, 8.09]})
+        >>> df2 = pd.DataFrame({'ds': pd.date_range(start = '2022-12-02', periods = 10, freq = 'D'),
+        ...                     'y': [8.71, 8.09, 7.84, 7.65, 8.02, 8.52, 8.18, 8.07, 8.25, 8.30]})
+        >>> df3 = pd.DataFrame({'ds': pd.date_range(start = '2022-12-03', periods = 10, freq = 'D'),
+        ...                     'y': [7.67, 7.64, 7.55, 8.25, 8.32, 9.59, 8.52, 7.55, 8.25, 8.09]})
+        >>> df3
+            ds	        y
+        0	2022-12-03	7.67
+        1	2022-12-04	7.64
+        2	2022-12-05	7.55
+        3	2022-12-06	8.25
+        4	2022-12-07	8.32
+        5	2022-12-08	9.59
+        6	2022-12-09	8.52
+        7	2022-12-10	7.55
+        8	2022-12-11	8.25
+        9	2022-12-12	8.09
+
+    You can create folds for a single dataframe.
+        >>> folds = m.crossvalidation_split_df(df3, k = 2, fold_pct = 0.2)
+        >>> folds
+        [(  ds            y
+            0 2022-12-03  7.67
+            1 2022-12-04  7.64
+            2 2022-12-05  7.55
+            3 2022-12-06  8.25
+            4 2022-12-07  8.32
+            5 2022-12-08  9.59
+            6 2022-12-09  8.52,
+            ds            y
+            0 2022-12-10  7.55
+            1 2022-12-11  8.25),
+        (   ds            y
+            0 2022-12-03  7.67
+            1 2022-12-04  7.64
+            2 2022-12-05  7.55
+            3 2022-12-06  8.25
+            4 2022-12-07  8.32
+            5 2022-12-08  9.59
+            6 2022-12-09  8.52
+            7 2022-12-10  7.55,
+            ds            y
+            0 2022-12-11  8.25
+            1 2022-12-12  8.09)]
+
+    We can also create a df with many IDs.
+        >>> df1['ID'] = 'data1'
+        >>> df2['ID'] = 'data2'
+        >>> df3['ID'] = 'data3'
+        >>> df = pd.concat((df1, df2, df3))
+
+    When using the df with many IDs, there are three types of possible crossvalidation. The default crossvalidation is performed according to a timestamp threshold. In this case, we can have a different number of samples for each time series per fold. This approach prevents time leakage.
+        >>> folds = m.crossvalidation_split_df(df, k = 2, fold_pct = 0.2)
+    One can notice how each of the folds has a different number of samples for the validation set. Nonetheless, time leakage does not occur.
+        >>> folds[0][1]
+            ds	y	ID
+        0	2022-12-10	8.09	data1
+        1	2022-12-10	8.25	data2
+        2	2022-12-11	8.30	data2
+        3	2022-12-10	7.55	data3
+        4	2022-12-11	8.25	data3
+        >>> folds[1][1]
+            ds	y	ID
+        0	2022-12-11	8.30	data2
+        1	2022-12-11	8.25	data3
+        2	2022-12-12	8.09	data3
+    In some applications, crossvalidating each of the time series locally may be more adequate.
+        >>> folds = m.crossvalidation_split_df(df, k = 2, fold_pct = 0.2, global_model_cv_type = 'local')
+    In this way, we prevent a different number of validation samples in each fold.
+        >>> folds[0][1]
+            ds	y	ID
+        0	2022-12-08	7.65	data1
+        1	2022-12-09	8.71	data1
+        2	2022-12-09	8.07	data2
+        3	2022-12-10	8.25	data2
+        4	2022-12-10	7.55	data3
+        5	2022-12-11	8.25	data3
+        >>> folds[1][1]
+            ds	y	ID
+        0	2022-12-09	8.71	data1
+        1	2022-12-10	8.09	data1
+        2	2022-12-10	8.25	data2
+        3	2022-12-11	8.30	data2
+        4	2022-12-11	8.25	data3
+        5	2022-12-12	8.09	data3
+    The last type of global model crossvalidation gets the time intersection among all the time series used. There is no time leakage in this case, and we preserve the same number of samples per fold. The only drawback of this approach is that some of the samples may not be used (those not in the time intersection).
+        >>> folds = m.crossvalidation_split_df(df, k = 2, fold_pct = 0.2, global_model_cv_type = 'intersect')
+        >>> folds[0][1]
+            ds	y	ID
+        0	2022-12-09	8.71	data1
+        1	2022-12-09	8.07	data2
+        2	2022-12-09	8.52	data3
+        0 2022-12-09  8.52}
+        >>> folds[1][1]
+            ds	y	ID
+        0	2022-12-10	8.09	data1
+        1	2022-12-10	8.25	data2
+        2	2022-12-10	7.55	data3
+    """
+    df, received_ID_col, received_single_time_series, _ = prep_or_copy_df(df)
+    # df = self._check_dataframe(df, check_y=False, exogenous=False) #add later
+    # freq = df_utils.infer_frequency(df, n_lags=self.max_lags, freq=freq) #add later
+    # df = model._handle_missing_data(df, freq=freq, predicting=False) #should be implemented, pass the model
+    folds = df_util_crossvalidation_split_df(
+        df,
+        n_lags=n_lags,  # TODO: needs to generalize
+        n_forecasts=n_forecasts,
+        k=k,
+        fold_pct=fold_pct,
+        fold_overlap_pct=fold_overlap_pct,
+        global_model_cv_type=global_model_cv_type,
+    )
+    if not received_ID_col and received_single_time_series:
+        # Delete ID column (__df__) of df_train and df_val of all folds in case ID was not previously provided
+        for i in range(len(folds)):
+            del folds[i][0]["ID"]
+            del folds[i][1]["ID"]
+    return folds

--- a/tot/df_utils.py
+++ b/tot/df_utils.py
@@ -2,7 +2,7 @@ import logging
 
 import numpy as np
 import pandas as pd
-from neuralprophet.df_utils import prep_or_copy_df
+from neuralprophet.df_utils import prep_or_copy_df, return_df_in_original_format
 
 log = logging.getLogger("tot.df_utils")
 
@@ -111,17 +111,13 @@ def split_df(df, test_percentage=0.25, local_split=False):
     return df_train, df_val
 
 
-def _crossvalidation_split_df(df, n_lags, n_forecasts, k, fold_pct, fold_overlap_pct=0.0):
+def __crossvalidation_split_df(df, k, fold_pct, fold_overlap_pct=0.0):
     """Splits data in k folds for crossvalidation.
 
     Parameters
     ----------
         df : pd.DataFrame
             data
-        n_lags : int
-            identical to NeuralProphet
-        n_forecasts : int
-            identical to NeuralProphet
         k : int
             number of CV folds
         fold_pct : float
@@ -144,7 +140,9 @@ def _crossvalidation_split_df(df, n_lags, n_forecasts, k, fold_pct, fold_overlap
     samples_overlap = int(fold_overlap_pct * samples_fold)
     assert samples_overlap < samples_fold
     min_train = total_samples - samples_fold - (k - 1) * (samples_fold - samples_overlap)
-    assert min_train >= samples_fold
+    assert (
+        min_train >= samples_fold
+    ), "Test percentage too large. Not enough train samples. Select smaller test percentage. "
     folds = []
     df_fold = df.copy(deep=True)
     for i in range(k, 0, -1):
@@ -156,9 +154,7 @@ def _crossvalidation_split_df(df, n_lags, n_forecasts, k, fold_pct, fold_overlap
     return folds
 
 
-def df_util_crossvalidation_split_df(
-    df, n_lags, n_forecasts, k, fold_pct, fold_overlap_pct=0.0, global_model_cv_type="global-time"
-):
+def _crossvalidation_split_df(df, k, fold_pct, fold_overlap_pct=0.0):
     """Splits data in k folds for crossvalidation.
 
     Parameters
@@ -194,44 +190,17 @@ def df_util_crossvalidation_split_df(
 
             validation data
     """
-    df, _, _, _ = prep_or_copy_df(df)
     if len(df["ID"].unique()) == 1:
         for df_name, df_i in df.groupby("ID"):
-            folds = _crossvalidation_split_df(df_i, n_lags, n_forecasts, k, fold_pct, fold_overlap_pct)
-    # else:
-    #     if global_model_cv_type == "global-time" or global_model_cv_type is None:
-    #         # Use time threshold to perform crossvalidation (the distribution of data of different episodes may not be equivalent)
-    #         folds = _crossvalidation_with_time_threshold(df, n_lags, n_forecasts, k, fold_pct, fold_overlap_pct)
-    #     elif global_model_cv_type == "local":
-    #         # Crossvalidate time series locally (time leakage may be a problem)
-    #         folds_dict = {}
-    #         for df_name, df_i in df.groupby("ID"):
-    #             folds_dict[df_name] = _crossvalidation_split_df(
-    #                 df_i, n_lags, n_forecasts, k, fold_pct, fold_overlap_pct
-    #             )
-    #         folds = unfold_dict_of_folds(folds_dict, k)
-    #     elif global_model_cv_type == "intersect":
-    #         # Use data only from the time period of intersection among time series
-    #         folds_dict = {}
-    #         # Check for intersection of time so time leakage does not occur among different time series
-    #         start_date, end_date = find_valid_time_interval_for_cv(df)
-    #         for df_name, df_i in df.groupby("ID"):
-    #             mask = (df_i["ds"] >= start_date) & (df_i["ds"] <= end_date)
-    #             df_i = df_i[mask].copy(deep=True)
-    #             folds_dict[df_name] = _crossvalidation_split_df(
-    #                 df_i, n_lags, n_forecasts, k, fold_pct, fold_overlap_pct
-    #             )
-    #         folds = unfold_dict_of_folds(folds_dict, k)
-    #     else:
-    #         raise ValueError(
-    #             "Please choose a valid type of global model crossvalidation (i.e. global-time, local, or intersect)"
-    #         )
+            folds = __crossvalidation_split_df(df_i, k, fold_pct, fold_overlap_pct)
+    else:
+        # implement procedure for multiple IDs
+        pass
+
     return folds
 
 
-def crossvalidation_split_df(
-    n_lags, n_forecasts, df, freq, k=5, fold_pct=0.1, fold_overlap_pct=0.5, global_model_cv_type="global-time"
-):
+def crossvalidation_split_df(df, freq, k=5, fold_pct=0.1, fold_overlap_pct=0.5):
     """Splits timeseries data in k folds for crossvalidation.
 
     Parameters
@@ -250,16 +219,6 @@ def crossvalidation_split_df(
             percentage of overall samples to be in each fold
         fold_overlap_pct : float
             percentage of overlap between the validation folds.
-        global_model_cv_type : str
-            Type of crossvalidation to apply to the dict of time series.
-
-                options:
-
-                    ``global-time`` (default) crossvalidation is performed according to a timestamp threshold.
-
-                    ``local`` each episode will be crossvalidated locally (may cause time leakage among different episodes)
-
-                    ``intersect`` only the time intersection of all the episodes will be considered. A considerable amount of data may not be used. However, this approach guarantees an equal number of train/test samples for each episode.
 
     Returns
     -------
@@ -271,17 +230,12 @@ def crossvalidation_split_df(
     See Also
     --------
         split_df : Splits timeseries df into train and validation sets.
-        double_crossvalidation_split_df : Splits timeseries data in two sets of k folds for crossvalidation on training and testing data.
 
     Examples
     --------
         >>> df1 = pd.DataFrame({'ds': pd.date_range(start = '2022-12-01', periods = 10, freq = 'D'),
         ...                     'y': [9.59, 8.52, 8.18, 8.07, 7.89, 8.09, 7.84, 7.65, 8.71, 8.09]})
-        >>> df2 = pd.DataFrame({'ds': pd.date_range(start = '2022-12-02', periods = 10, freq = 'D'),
-        ...                     'y': [8.71, 8.09, 7.84, 7.65, 8.02, 8.52, 8.18, 8.07, 8.25, 8.30]})
-        >>> df3 = pd.DataFrame({'ds': pd.date_range(start = '2022-12-03', periods = 10, freq = 'D'),
-        ...                     'y': [7.67, 7.64, 7.55, 8.25, 8.32, 9.59, 8.52, 7.55, 8.25, 8.09]})
-        >>> df3
+        >>> df1
             ds	        y
         0	2022-12-03	7.67
         1	2022-12-04	7.64
@@ -293,104 +247,23 @@ def crossvalidation_split_df(
         7	2022-12-10	7.55
         8	2022-12-11	8.25
         9	2022-12-12	8.09
-
-    You can create folds for a single dataframe.
-        >>> folds = m.crossvalidation_split_df(df3, k = 2, fold_pct = 0.2)
-        >>> folds
-        [(  ds            y
-            0 2022-12-03  7.67
-            1 2022-12-04  7.64
-            2 2022-12-05  7.55
-            3 2022-12-06  8.25
-            4 2022-12-07  8.32
-            5 2022-12-08  9.59
-            6 2022-12-09  8.52,
-            ds            y
-            0 2022-12-10  7.55
-            1 2022-12-11  8.25),
-        (   ds            y
-            0 2022-12-03  7.67
-            1 2022-12-04  7.64
-            2 2022-12-05  7.55
-            3 2022-12-06  8.25
-            4 2022-12-07  8.32
-            5 2022-12-08  9.59
-            6 2022-12-09  8.52
-            7 2022-12-10  7.55,
-            ds            y
-            0 2022-12-11  8.25
-            1 2022-12-12  8.09)]
-
-    We can also create a df with many IDs.
-        >>> df1['ID'] = 'data1'
-        >>> df2['ID'] = 'data2'
-        >>> df3['ID'] = 'data3'
-        >>> df = pd.concat((df1, df2, df3))
-
-    When using the df with many IDs, there are three types of possible crossvalidation. The default crossvalidation is performed according to a timestamp threshold. In this case, we can have a different number of samples for each time series per fold. This approach prevents time leakage.
-        >>> folds = m.crossvalidation_split_df(df, k = 2, fold_pct = 0.2)
-    One can notice how each of the folds has a different number of samples for the validation set. Nonetheless, time leakage does not occur.
-        >>> folds[0][1]
-            ds	y	ID
-        0	2022-12-10	8.09	data1
-        1	2022-12-10	8.25	data2
-        2	2022-12-11	8.30	data2
-        3	2022-12-10	7.55	data3
-        4	2022-12-11	8.25	data3
-        >>> folds[1][1]
-            ds	y	ID
-        0	2022-12-11	8.30	data2
-        1	2022-12-11	8.25	data3
-        2	2022-12-12	8.09	data3
-    In some applications, crossvalidating each of the time series locally may be more adequate.
-        >>> folds = m.crossvalidation_split_df(df, k = 2, fold_pct = 0.2, global_model_cv_type = 'local')
-    In this way, we prevent a different number of validation samples in each fold.
-        >>> folds[0][1]
-            ds	y	ID
-        0	2022-12-08	7.65	data1
-        1	2022-12-09	8.71	data1
-        2	2022-12-09	8.07	data2
-        3	2022-12-10	8.25	data2
-        4	2022-12-10	7.55	data3
-        5	2022-12-11	8.25	data3
-        >>> folds[1][1]
-            ds	y	ID
-        0	2022-12-09	8.71	data1
-        1	2022-12-10	8.09	data1
-        2	2022-12-10	8.25	data2
-        3	2022-12-11	8.30	data2
-        4	2022-12-11	8.25	data3
-        5	2022-12-12	8.09	data3
-    The last type of global model crossvalidation gets the time intersection among all the time series used. There is no time leakage in this case, and we preserve the same number of samples per fold. The only drawback of this approach is that some of the samples may not be used (those not in the time intersection).
-        >>> folds = m.crossvalidation_split_df(df, k = 2, fold_pct = 0.2, global_model_cv_type = 'intersect')
-        >>> folds[0][1]
-            ds	y	ID
-        0	2022-12-09	8.71	data1
-        1	2022-12-09	8.07	data2
-        2	2022-12-09	8.52	data3
-        0 2022-12-09  8.52}
-        >>> folds[1][1]
-            ds	y	ID
-        0	2022-12-10	8.09	data1
-        1	2022-12-10	8.25	data2
-        2	2022-12-10	7.55	data3
     """
     df, received_ID_col, received_single_time_series, _ = prep_or_copy_df(df)
-    # df = self._check_dataframe(df, check_y=False, exogenous=False) #add later
-    # freq = df_utils.infer_frequency(df, n_lags=self.max_lags, freq=freq) #add later
-    # df = model._handle_missing_data(df, freq=freq, predicting=False) #should be implemented, pass the model
-    folds = df_util_crossvalidation_split_df(
+    # df = self._check_dataframe(df, check_y=False, exogenous=False) #TODO: add via restructured pipeline
+    # freq = df_utils.infer_frequency(df, n_lags=self.max_lags, freq=freq) #TODO: add via restructured pipeline
+    # df = model._handle_missing_data(df, freq=freq, predicting=False) #TODO: add via restructured pipeline
+    folds = _crossvalidation_split_df(
         df,
-        n_lags=n_lags,  # TODO: needs to generalize
-        n_forecasts=n_forecasts,
         k=k,
         fold_pct=fold_pct,
         fold_overlap_pct=fold_overlap_pct,
-        global_model_cv_type=global_model_cv_type,
     )
     if not received_ID_col and received_single_time_series:
         # Delete ID column (__df__) of df_train and df_val of all folds in case ID was not previously provided
+        new_folds = []
         for i in range(len(folds)):
-            del folds[i][0]["ID"]
-            del folds[i][1]["ID"]
+            df_train = return_df_in_original_format(folds[i][0])
+            df_val = return_df_in_original_format(folds[i][1])
+            new_folds.append((df_train, df_val))
+        folds = new_folds
     return folds

--- a/tot/df_utils.py
+++ b/tot/df_utils.py
@@ -267,3 +267,7 @@ def crossvalidation_split_df(df, freq, k=5, fold_pct=0.1, fold_overlap_pct=0.5):
             new_folds.append((df_train, df_val))
         folds = new_folds
     return folds
+
+
+def _check_min_df_len(df, min_len):
+    assert len(df) > min_len, "df has not enough data to create a single input sample."

--- a/tot/experiment.py
+++ b/tot/experiment.py
@@ -213,14 +213,11 @@ class CrossValidationExperiment(Experiment):
 
     def run(self):
         folds = crossvalidation_split_df(
-            n_lags=self.params["n_lags"],
-            n_forecasts=self.params["n_forecasts"],
             df=self.data.df,
             freq=self.data.freq,
             k=self.num_folds,
-            fold_pct=self.test_percentage / 100.0,
-            fold_overlap_pct=self.fold_overlap_pct / 100.0,
-            global_model_cv_type=self.global_model_cv_type,
+            fold_pct=self.test_percentage,
+            fold_overlap_pct=self.fold_overlap_pct,
         )
         # init empty dicts with list for fold-wise metrics
         self.results_cv_train = self.metadata.copy()

--- a/tot/experiment.py
+++ b/tot/experiment.py
@@ -233,7 +233,6 @@ class CrossValidationExperiment(Experiment):
                 args = [(df_train, df_test, current_fold) for current_fold, (df_train, df_test) in enumerate(folds)]
                 pool.map_async(
                     self._run_fold,
-                    model,
                     args,
                     callback=self._log_results,
                     error_callback=self._log_error,

--- a/tot/models.py
+++ b/tot/models.py
@@ -84,14 +84,6 @@ class Model(ABC):
         """
         return df
 
-    # def maybe_add_first_inputs_to_df(self, df_train, df_test):
-    #     """
-    #     if historic data is used as input to the model to make prediction: adds number of past observations
-    #     (e.g. n_lags or season_length) values to start of df_test.
-    #     else (time-features only): returns unchanged df_test.
-    #     """
-    #     return df_test.reset_index(drop=True)
-
     def maybe_add_first_inputs_to_df(self, df_train, df_test):
         """Adds last n_lags values from df_train to start of df_test."""
         if self.n_lags > 0:
@@ -116,14 +108,6 @@ class Model(ABC):
                 received_single_time_series_test,
             )
         return df_test
-
-    # def maybe_drop_first_forecasts(self, predicted, df):
-    #     """
-    #     if historic data is used as input to the model to make prediction: removes number of past observations
-    #     (e.g. n_lags or season_length) values from predicted and df_test.
-    #     else (time-features only): returns unchanged df_test.
-    #     """
-    #     return predicted.reset_index(drop=True), df.reset_index(drop=True)
 
     def maybe_drop_first_forecasts(self, predicted, df):
         """
@@ -275,99 +259,6 @@ class NeuralProphetModel(Model):
             fcst_df, df = self.maybe_drop_first_forecasts(fcst_df, df)
         fcst_df, df = self.maybe_drop_added_dates(fcst_df, df)
         return fcst_df
-
-    # def maybe_add_first_inputs_to_df(self, df_train, df_test):
-    #     """Adds last n_lags values from df_train to start of df_test."""
-    #     if self.model.n_lags > 0:
-    #         df_train, _, _, _ = df_utils.prep_or_copy_df(df_train)
-    #         (
-    #             df_test,
-    #             received_ID_col_test,
-    #             received_single_time_series_test,
-    #             _,
-    #         ) = df_utils.prep_or_copy_df(df_test)
-    #         df_test_new = pd.DataFrame()
-    #         for df_name, df_test_i in df_test.groupby("ID"):
-    #             df_train_i = df_train[df_train["ID"] == df_name].copy(deep=True)
-    #             df_test_i = pd.concat(
-    #                 [df_train_i.tail(self.model.n_lags), df_test_i],
-    #                 ignore_index=True,
-    #             )
-    #             df_test_new = pd.concat((df_test_new, df_test_i), ignore_index=True)
-    #         df_test = df_utils.return_df_in_original_format(
-    #             df_test_new,
-    #             received_ID_col_test,
-    #             received_single_time_series_test,
-    #         )
-    #     return df_test
-
-    # def maybe_drop_first_forecasts(self, predicted, df):
-    #     """
-    #     if Model with lags: removes first n_lags values from predicted and df
-    #     else (time-features only): returns unchanged df
-    #     """
-    #     if self.model.n_lags > 0:
-    #         (
-    #             predicted,
-    #             received_ID_col_pred,
-    #             received_single_time_series_pred,
-    #             _,
-    #         ) = df_utils.prep_or_copy_df(predicted)
-    #         (
-    #             df,
-    #             received_ID_col_df,
-    #             received_single_time_series_df,
-    #             _,
-    #         ) = df_utils.prep_or_copy_df(df)
-    #         predicted_new = pd.DataFrame()
-    #         df_new = pd.DataFrame()
-    #         for df_name, df_i in df.groupby("ID"):
-    #             predicted_i = predicted[predicted["ID"] == df_name].copy(deep=True)
-    #             predicted_i = predicted_i[self.model.n_lags :]
-    #             df_i = df_i[self.model.n_lags :]
-    #             df_new = pd.concat((df_new, df_i), ignore_index=True)
-    #             predicted_new = pd.concat((predicted_new, predicted_i), ignore_index=True)
-    #         df = df_utils.return_df_in_original_format(df_new, received_ID_col_df, received_single_time_series_df)
-    #         predicted = df_utils.return_df_in_original_format(
-    #             predicted_new,
-    #             received_ID_col_pred,
-    #             received_single_time_series_pred,
-    #         )
-    #     return predicted, df
-
-    def maybe_drop_added_dates(self, predicted, df):
-        """if Model imputed any dates: removes any dates in predicted which are not in df_test."""
-        (
-            predicted,
-            received_ID_col_pred,
-            received_single_time_series_pred,
-            _,
-        ) = df_utils.prep_or_copy_df(predicted)
-        (
-            df,
-            received_ID_col_df,
-            received_single_time_series_df,
-            _,
-        ) = df_utils.prep_or_copy_df(df)
-        predicted_new = pd.DataFrame()
-        df_new = pd.DataFrame()
-        for df_name, df_i in df.groupby("ID"):
-            predicted_i = predicted[predicted["ID"] == df_name].copy(deep=True)
-            df_i["ds"] = convert_to_datetime(df_i["ds"])
-            df_i.set_index("ds", inplace=True)
-            predicted_i.set_index("time", inplace=True)
-            predicted_i = predicted_i.loc[df_i.index]
-            predicted_i = predicted_i.reset_index()
-            df_i = df_i.reset_index()
-            df_new = pd.concat((df_new, df_i), ignore_index=True)
-            predicted_new = pd.concat((predicted_new, predicted_i), ignore_index=True)
-        df = df_utils.return_df_in_original_format(df_new, received_ID_col_df, received_single_time_series_df)
-        predicted = df_utils.return_df_in_original_format(
-            predicted_new,
-            received_ID_col_pred,
-            received_single_time_series_pred,
-        )
-        return predicted, df
 
 
 @dataclass
@@ -836,99 +727,6 @@ class LinearRegressionModel(Model):
             fcst_df[name] = yhat
 
         return fcst_df
-
-    # def maybe_add_first_inputs_to_df(self, df_train, df_test):
-    #     """Adds last n_lags values from df_train to start of df_test."""
-    #     if self.n_lags > 0:
-    #         df_train, _, _, _ = df_utils.prep_or_copy_df(df_train)
-    #         (
-    #             df_test,
-    #             received_ID_col_test,
-    #             received_single_time_series_test,
-    #             _,
-    #         ) = df_utils.prep_or_copy_df(df_test)
-    #         df_test_new = pd.DataFrame()
-    #         for df_name, df_test_i in df_test.groupby("ID"):
-    #             df_train_i = df_train[df_train["ID"] == df_name].copy(deep=True)
-    #             df_test_i = pd.concat(
-    #                 [df_train_i.tail(self.n_lags), df_test_i],
-    #                 ignore_index=True,
-    #             )
-    #             df_test_new = pd.concat((df_test_new, df_test_i), ignore_index=True)
-    #         df_test = df_utils.return_df_in_original_format(
-    #             df_test_new,
-    #             received_ID_col_test,
-    #             received_single_time_series_test,
-    #         )
-    #     return df_test
-    #
-    # def maybe_drop_first_forecasts(self, predicted, df):
-    #     """
-    #     if Model with lags: removes first n_lags values from predicted and df
-    #     else (time-features only): returns unchanged df
-    #     """
-    #     if self.n_lags > 0:
-    #         (
-    #             predicted,
-    #             received_ID_col_pred,
-    #             received_single_time_series_pred,
-    #             _,
-    #         ) = df_utils.prep_or_copy_df(predicted)
-    #         (
-    #             df,
-    #             received_ID_col_df,
-    #             received_single_time_series_df,
-    #             _,
-    #         ) = df_utils.prep_or_copy_df(df)
-    #         predicted_new = pd.DataFrame()
-    #         df_new = pd.DataFrame()
-    #         for df_name, df_i in df.groupby("ID"):
-    #             predicted_i = predicted[predicted["ID"] == df_name].copy(deep=True)
-    #             predicted_i = predicted_i[self.n_lags :]
-    #             df_i = df_i[self.n_lags :]
-    #             df_new = pd.concat((df_new, df_i), ignore_index=True)
-    #             predicted_new = pd.concat((predicted_new, predicted_i), ignore_index=True)
-    #         df = df_utils.return_df_in_original_format(df_new, received_ID_col_df, received_single_time_series_df)
-    #         predicted = df_utils.return_df_in_original_format(
-    #             predicted_new,
-    #             received_ID_col_pred,
-    #             received_single_time_series_pred,
-    #         )
-    #     return predicted, df
-
-    def maybe_drop_added_dates(self, predicted, df):
-        """if Model imputed any dates: removes any dates in predicted which are not in df_test."""
-        (
-            predicted,
-            received_ID_col_pred,
-            received_single_time_series_pred,
-            _,
-        ) = df_utils.prep_or_copy_df(predicted)
-        (
-            df,
-            received_ID_col_df,
-            received_single_time_series_df,
-            _,
-        ) = df_utils.prep_or_copy_df(df)
-        predicted_new = pd.DataFrame()
-        df_new = pd.DataFrame()
-        for df_name, df_i in df.groupby("ID"):
-            predicted_i = predicted[predicted["ID"] == df_name].copy(deep=True)
-            df_i["ds"] = convert_to_datetime(df_i["ds"])
-            df_i.set_index("ds", inplace=True)
-            predicted_i.set_index("ds", inplace=True)
-            predicted_i = predicted_i.loc[df_i.index]
-            predicted_i = predicted_i.reset_index()
-            df_i = df_i.reset_index()
-            df_new = pd.concat((df_new, df_i), ignore_index=True)
-            predicted_new = pd.concat((predicted_new, predicted_i), ignore_index=True)
-        df = df_utils.return_df_in_original_format(df_new, received_ID_col_df, received_single_time_series_df)
-        predicted = df_utils.return_df_in_original_format(
-            predicted_new,
-            received_ID_col_pred,
-            received_single_time_series_pred,
-        )
-        return predicted, df
 
     def __handle_missing_data(self, df, freq, predicting):
         """Checks and normalizes new data

--- a/tot/models.py
+++ b/tot/models.py
@@ -84,21 +84,80 @@ class Model(ABC):
         """
         return df
 
+    # def maybe_add_first_inputs_to_df(self, df_train, df_test):
+    #     """
+    #     if historic data is used as input to the model to make prediction: adds number of past observations
+    #     (e.g. n_lags or season_length) values to start of df_test.
+    #     else (time-features only): returns unchanged df_test.
+    #     """
+    #     return df_test.reset_index(drop=True)
+
     def maybe_add_first_inputs_to_df(self, df_train, df_test):
-        """
-        if historic data is used as input to the model to make prediction: adds number of past observations
-        (e.g. n_lags or season_length) values to start of df_test.
-        else (time-features only): returns unchanged df_test.
-        """
-        return df_test.reset_index(drop=True)
+        """Adds last n_lags values from df_train to start of df_test."""
+        if self.n_lags > 0:
+            df_train, _, _, _ = df_utils.prep_or_copy_df(df_train)
+            (
+                df_test,
+                received_ID_col_test,
+                received_single_time_series_test,
+                _,
+            ) = df_utils.prep_or_copy_df(df_test)
+            df_test_new = pd.DataFrame()
+            for df_name, df_test_i in df_test.groupby("ID"):
+                df_train_i = df_train[df_train["ID"] == df_name].copy(deep=True)
+                df_test_i = pd.concat(
+                    [df_train_i.tail(self.n_lags), df_test_i],
+                    ignore_index=True,
+                )
+                df_test_new = pd.concat((df_test_new, df_test_i), ignore_index=True)
+            df_test = df_utils.return_df_in_original_format(
+                df_test_new,
+                received_ID_col_test,
+                received_single_time_series_test,
+            )
+        return df_test
+
+    # def maybe_drop_first_forecasts(self, predicted, df):
+    #     """
+    #     if historic data is used as input to the model to make prediction: removes number of past observations
+    #     (e.g. n_lags or season_length) values from predicted and df_test.
+    #     else (time-features only): returns unchanged df_test.
+    #     """
+    #     return predicted.reset_index(drop=True), df.reset_index(drop=True)
 
     def maybe_drop_first_forecasts(self, predicted, df):
         """
-        if historic data is used as input to the model to make prediction: removes number of past observations
-        (e.g. n_lags or season_length) values from predicted and df_test.
-        else (time-features only): returns unchanged df_test.
+        if Model with lags: removes first n_lags values from predicted and df
+        else (time-features only): returns unchanged df
         """
-        return predicted.reset_index(drop=True), df.reset_index(drop=True)
+        if self.n_lags > 0:
+            (
+                predicted,
+                received_ID_col_pred,
+                received_single_time_series_pred,
+                _,
+            ) = df_utils.prep_or_copy_df(predicted)
+            (
+                df,
+                received_ID_col_df,
+                received_single_time_series_df,
+                _,
+            ) = df_utils.prep_or_copy_df(df)
+            predicted_new = pd.DataFrame()
+            df_new = pd.DataFrame()
+            for df_name, df_i in df.groupby("ID"):
+                predicted_i = predicted[predicted["ID"] == df_name].copy(deep=True)
+                predicted_i = predicted_i[self.n_lags :]
+                df_i = df_i[self.n_lags :]
+                df_new = pd.concat((df_new, df_i), ignore_index=True)
+                predicted_new = pd.concat((predicted_new, predicted_i), ignore_index=True)
+            df = df_utils.return_df_in_original_format(df_new, received_ID_col_df, received_single_time_series_df)
+            predicted = df_utils.return_df_in_original_format(
+                predicted_new,
+                received_ID_col_pred,
+                received_single_time_series_pred,
+            )
+        return predicted, df
 
     def maybe_drop_added_dates(self, predicted, df):
         """if Model imputed any dates: removes any dates in predicted which are not in df_test."""
@@ -143,6 +202,22 @@ class ProphetModel(Model):
         fcst = self.model.predict(df=df)
         fcst_df = pd.DataFrame({"time": fcst.ds, "y": df.y, "yhat1": fcst.yhat})
         return fcst_df
+
+    def maybe_add_first_inputs_to_df(self, df_train, df_test):
+        """
+        if historic data is used as input to the model to make prediction: adds number of past observations
+        (e.g. n_lags or season_length) values to start of df_test.
+        else (time-features only): returns unchanged df_test.
+        """
+        return df_test.reset_index(drop=True)
+
+    def maybe_drop_first_forecasts(self, predicted, df):
+        """
+        if historic data is used as input to the model to make prediction: removes number of past observations
+        (e.g. n_lags or season_length) values from predicted and df_test.
+        else (time-features only): returns unchanged df_test.
+        """
+        return predicted.reset_index(drop=True), df.reset_index(drop=True)
 
 
 @dataclass
@@ -201,64 +276,64 @@ class NeuralProphetModel(Model):
         fcst_df, df = self.maybe_drop_added_dates(fcst_df, df)
         return fcst_df
 
-    def maybe_add_first_inputs_to_df(self, df_train, df_test):
-        """Adds last n_lags values from df_train to start of df_test."""
-        if self.model.n_lags > 0:
-            df_train, _, _, _ = df_utils.prep_or_copy_df(df_train)
-            (
-                df_test,
-                received_ID_col_test,
-                received_single_time_series_test,
-                _,
-            ) = df_utils.prep_or_copy_df(df_test)
-            df_test_new = pd.DataFrame()
-            for df_name, df_test_i in df_test.groupby("ID"):
-                df_train_i = df_train[df_train["ID"] == df_name].copy(deep=True)
-                df_test_i = pd.concat(
-                    [df_train_i.tail(self.model.n_lags), df_test_i],
-                    ignore_index=True,
-                )
-                df_test_new = pd.concat((df_test_new, df_test_i), ignore_index=True)
-            df_test = df_utils.return_df_in_original_format(
-                df_test_new,
-                received_ID_col_test,
-                received_single_time_series_test,
-            )
-        return df_test
+    # def maybe_add_first_inputs_to_df(self, df_train, df_test):
+    #     """Adds last n_lags values from df_train to start of df_test."""
+    #     if self.model.n_lags > 0:
+    #         df_train, _, _, _ = df_utils.prep_or_copy_df(df_train)
+    #         (
+    #             df_test,
+    #             received_ID_col_test,
+    #             received_single_time_series_test,
+    #             _,
+    #         ) = df_utils.prep_or_copy_df(df_test)
+    #         df_test_new = pd.DataFrame()
+    #         for df_name, df_test_i in df_test.groupby("ID"):
+    #             df_train_i = df_train[df_train["ID"] == df_name].copy(deep=True)
+    #             df_test_i = pd.concat(
+    #                 [df_train_i.tail(self.model.n_lags), df_test_i],
+    #                 ignore_index=True,
+    #             )
+    #             df_test_new = pd.concat((df_test_new, df_test_i), ignore_index=True)
+    #         df_test = df_utils.return_df_in_original_format(
+    #             df_test_new,
+    #             received_ID_col_test,
+    #             received_single_time_series_test,
+    #         )
+    #     return df_test
 
-    def maybe_drop_first_forecasts(self, predicted, df):
-        """
-        if Model with lags: removes first n_lags values from predicted and df
-        else (time-features only): returns unchanged df
-        """
-        if self.model.n_lags > 0:
-            (
-                predicted,
-                received_ID_col_pred,
-                received_single_time_series_pred,
-                _,
-            ) = df_utils.prep_or_copy_df(predicted)
-            (
-                df,
-                received_ID_col_df,
-                received_single_time_series_df,
-                _,
-            ) = df_utils.prep_or_copy_df(df)
-            predicted_new = pd.DataFrame()
-            df_new = pd.DataFrame()
-            for df_name, df_i in df.groupby("ID"):
-                predicted_i = predicted[predicted["ID"] == df_name].copy(deep=True)
-                predicted_i = predicted_i[self.model.n_lags :]
-                df_i = df_i[self.model.n_lags :]
-                df_new = pd.concat((df_new, df_i), ignore_index=True)
-                predicted_new = pd.concat((predicted_new, predicted_i), ignore_index=True)
-            df = df_utils.return_df_in_original_format(df_new, received_ID_col_df, received_single_time_series_df)
-            predicted = df_utils.return_df_in_original_format(
-                predicted_new,
-                received_ID_col_pred,
-                received_single_time_series_pred,
-            )
-        return predicted, df
+    # def maybe_drop_first_forecasts(self, predicted, df):
+    #     """
+    #     if Model with lags: removes first n_lags values from predicted and df
+    #     else (time-features only): returns unchanged df
+    #     """
+    #     if self.model.n_lags > 0:
+    #         (
+    #             predicted,
+    #             received_ID_col_pred,
+    #             received_single_time_series_pred,
+    #             _,
+    #         ) = df_utils.prep_or_copy_df(predicted)
+    #         (
+    #             df,
+    #             received_ID_col_df,
+    #             received_single_time_series_df,
+    #             _,
+    #         ) = df_utils.prep_or_copy_df(df)
+    #         predicted_new = pd.DataFrame()
+    #         df_new = pd.DataFrame()
+    #         for df_name, df_i in df.groupby("ID"):
+    #             predicted_i = predicted[predicted["ID"] == df_name].copy(deep=True)
+    #             predicted_i = predicted_i[self.model.n_lags :]
+    #             df_i = df_i[self.model.n_lags :]
+    #             df_new = pd.concat((df_new, df_i), ignore_index=True)
+    #             predicted_new = pd.concat((predicted_new, predicted_i), ignore_index=True)
+    #         df = df_utils.return_df_in_original_format(df_new, received_ID_col_df, received_single_time_series_df)
+    #         predicted = df_utils.return_df_in_original_format(
+    #             predicted_new,
+    #             received_ID_col_pred,
+    #             received_single_time_series_pred,
+    #         )
+    #     return predicted, df
 
     def maybe_drop_added_dates(self, predicted, df):
         """if Model imputed any dates: removes any dates in predicted which are not in df_test."""
@@ -323,6 +398,22 @@ class TorchProphetModel(NeuralProphetModel):
         self.n_forecasts = self.model.n_forecasts
         self.n_lags = self.model.n_lags
         self.season_length = None
+
+    def maybe_add_first_inputs_to_df(self, df_train, df_test):
+        """
+        if historic data is used as input to the model to make prediction: adds number of past observations
+        (e.g. n_lags or season_length) values to start of df_test.
+        else (time-features only): returns unchanged df_test.
+        """
+        return df_test.reset_index(drop=True)
+
+    def maybe_drop_first_forecasts(self, predicted, df):
+        """
+        if historic data is used as input to the model to make prediction: removes number of past observations
+        (e.g. n_lags or season_length) values from predicted and df_test.
+        else (time-features only): returns unchanged df_test.
+        """
+        return predicted.reset_index(drop=True), df.reset_index(drop=True)
 
 
 @dataclass
@@ -746,64 +837,64 @@ class LinearRegressionModel(Model):
 
         return fcst_df
 
-    def maybe_add_first_inputs_to_df(self, df_train, df_test):
-        """Adds last n_lags values from df_train to start of df_test."""
-        if self.n_lags > 0:
-            df_train, _, _, _ = df_utils.prep_or_copy_df(df_train)
-            (
-                df_test,
-                received_ID_col_test,
-                received_single_time_series_test,
-                _,
-            ) = df_utils.prep_or_copy_df(df_test)
-            df_test_new = pd.DataFrame()
-            for df_name, df_test_i in df_test.groupby("ID"):
-                df_train_i = df_train[df_train["ID"] == df_name].copy(deep=True)
-                df_test_i = pd.concat(
-                    [df_train_i.tail(self.n_lags), df_test_i],
-                    ignore_index=True,
-                )
-                df_test_new = pd.concat((df_test_new, df_test_i), ignore_index=True)
-            df_test = df_utils.return_df_in_original_format(
-                df_test_new,
-                received_ID_col_test,
-                received_single_time_series_test,
-            )
-        return df_test
-
-    def maybe_drop_first_forecasts(self, predicted, df):
-        """
-        if Model with lags: removes first n_lags values from predicted and df
-        else (time-features only): returns unchanged df
-        """
-        if self.n_lags > 0:
-            (
-                predicted,
-                received_ID_col_pred,
-                received_single_time_series_pred,
-                _,
-            ) = df_utils.prep_or_copy_df(predicted)
-            (
-                df,
-                received_ID_col_df,
-                received_single_time_series_df,
-                _,
-            ) = df_utils.prep_or_copy_df(df)
-            predicted_new = pd.DataFrame()
-            df_new = pd.DataFrame()
-            for df_name, df_i in df.groupby("ID"):
-                predicted_i = predicted[predicted["ID"] == df_name].copy(deep=True)
-                predicted_i = predicted_i[self.n_lags :]
-                df_i = df_i[self.n_lags :]
-                df_new = pd.concat((df_new, df_i), ignore_index=True)
-                predicted_new = pd.concat((predicted_new, predicted_i), ignore_index=True)
-            df = df_utils.return_df_in_original_format(df_new, received_ID_col_df, received_single_time_series_df)
-            predicted = df_utils.return_df_in_original_format(
-                predicted_new,
-                received_ID_col_pred,
-                received_single_time_series_pred,
-            )
-        return predicted, df
+    # def maybe_add_first_inputs_to_df(self, df_train, df_test):
+    #     """Adds last n_lags values from df_train to start of df_test."""
+    #     if self.n_lags > 0:
+    #         df_train, _, _, _ = df_utils.prep_or_copy_df(df_train)
+    #         (
+    #             df_test,
+    #             received_ID_col_test,
+    #             received_single_time_series_test,
+    #             _,
+    #         ) = df_utils.prep_or_copy_df(df_test)
+    #         df_test_new = pd.DataFrame()
+    #         for df_name, df_test_i in df_test.groupby("ID"):
+    #             df_train_i = df_train[df_train["ID"] == df_name].copy(deep=True)
+    #             df_test_i = pd.concat(
+    #                 [df_train_i.tail(self.n_lags), df_test_i],
+    #                 ignore_index=True,
+    #             )
+    #             df_test_new = pd.concat((df_test_new, df_test_i), ignore_index=True)
+    #         df_test = df_utils.return_df_in_original_format(
+    #             df_test_new,
+    #             received_ID_col_test,
+    #             received_single_time_series_test,
+    #         )
+    #     return df_test
+    #
+    # def maybe_drop_first_forecasts(self, predicted, df):
+    #     """
+    #     if Model with lags: removes first n_lags values from predicted and df
+    #     else (time-features only): returns unchanged df
+    #     """
+    #     if self.n_lags > 0:
+    #         (
+    #             predicted,
+    #             received_ID_col_pred,
+    #             received_single_time_series_pred,
+    #             _,
+    #         ) = df_utils.prep_or_copy_df(predicted)
+    #         (
+    #             df,
+    #             received_ID_col_df,
+    #             received_single_time_series_df,
+    #             _,
+    #         ) = df_utils.prep_or_copy_df(df)
+    #         predicted_new = pd.DataFrame()
+    #         df_new = pd.DataFrame()
+    #         for df_name, df_i in df.groupby("ID"):
+    #             predicted_i = predicted[predicted["ID"] == df_name].copy(deep=True)
+    #             predicted_i = predicted_i[self.n_lags :]
+    #             df_i = df_i[self.n_lags :]
+    #             df_new = pd.concat((df_new, df_i), ignore_index=True)
+    #             predicted_new = pd.concat((predicted_new, predicted_i), ignore_index=True)
+    #         df = df_utils.return_df_in_original_format(df_new, received_ID_col_df, received_single_time_series_df)
+    #         predicted = df_utils.return_df_in_original_format(
+    #             predicted_new,
+    #             received_ID_col_pred,
+    #             received_single_time_series_pred,
+    #         )
+    #     return predicted, df
 
     def maybe_drop_added_dates(self, predicted, df):
         """if Model imputed any dates: removes any dates in predicted which are not in df_test."""

--- a/tot/models.py
+++ b/tot/models.py
@@ -9,7 +9,7 @@ import pandas as pd
 from neuralprophet import NeuralProphet, TorchProphet, df_utils
 
 from tot.df_utils import reshape_raw_predictions_to_forecast_df
-from tot.utils import _convert_seasonality_to_season_length, _get_seasons, convert_df_to_TimeSeries, convert_to_datetime
+from tot.utils import _convert_seasonality_to_season_length, _get_seasons, convert_df_to_TimeSeries
 
 # check import of implemented models and consider order of imports
 try:


### PR DESCRIPTION
🔬 Background
We need a functionality for splitting the dataframe into train and val. Since we want to offer crossvalidation, we need a function that splits the datafram in the crossvalidation case. 
Additionally to splitting the dataframe, we want to append the last inputs of the train dataframe to the beginning of the test_data. That feature depends on the model configuration. If the model predicts based on lags or comparable histroric time steps, then the test dataframe can be added.

🔮 Key changes
Add to df_utils.py:
*`split_df()`
*`crossvalidation_split_df()`
Restructure:
* call `maybe_add_first_inputs()`, `maybe_drop_first_inputs()` within `predit()`, comment: should not be user-facing. Temporary solution.
* call `new split_df()` / `crossvalidation_split_df()` in experiment procedure. 


📋 Review Checklist
- [ ]  I have performed a self-review of my own code.
- [ ]  I have commented my code, added docstrings and data types to function definitions.
- [ ]  I have added pytests for running a single model