### PR TITLE
separate predict step from evaluation step

### DIFF
--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -58,7 +58,7 @@ def test_simple_experiment():
         metrics=list(ERROR_FUNCTIONS.keys()),
         test_percentage=0.25,
     )
-    result_train, result_val = exp.run()
+    fcst_train, fcst_test, result_train, result_val = exp.run()
     log.debug(result_val)
     log.info("#### Done with test_simple_experiment")
 
@@ -79,6 +79,6 @@ def test_cv_experiment():
         fold_overlap_pct=0,
         save_dir=SAVE_DIR,
     )
-    result_train, result_val = exp_cv.run()
+    fcst_train, fcst_test, result_train, result_val = exp_cv.run()
     log.debug(result_val)
     log.info("#### Done with test_cv_experiment")

--- a/tot/benchmark.py
+++ b/tot/benchmark.py
@@ -151,7 +151,7 @@ class CVBenchmark(Benchmark, ABC):
         return df_metrics_summary
 
     def run(self, verbose=True):
-        self.fcst_train, self.fcst_test, df_metrics_train, df_metrics_test = super().run(verbose=verbose)
+        df_metrics_train, df_metrics_test = super().run(verbose=verbose)
         self.df_metrics_train = df_metrics_train
         self.df_metrics_test = df_metrics_test
         df_metrics_summary_train = self._summarize_cv_metrics(df_metrics_train)

--- a/tot/exp_utils.py
+++ b/tot/exp_utils.py
@@ -30,8 +30,12 @@ def evaluate_forecast(fcst_train, fcst_test, metrics, metadata=None):
         Result of evaluation on test set.
     """
 
-    result_train = metadata.copy()
-    result_test = metadata.copy()
+    if metadata is not None:
+        result_train = metadata.copy()
+        result_test = metadata.copy()
+    else:
+        result_train = {}
+        result_test = {}
 
     for metric in metrics:
         # todo: parallelize

--- a/tot/exp_utils.py
+++ b/tot/exp_utils.py
@@ -1,0 +1,49 @@
+import logging
+import math
+from typing import List, Tuple
+
+import numpy as np
+
+from tot.metrics import ERROR_FUNCTIONS
+
+log = logging.getLogger("tot.exp_utils")
+
+
+def evaluate_forecast(fcst_train, fcst_test, metrics, metadata=None):
+    result_train = metadata.copy()
+    result_test = metadata.copy()
+
+    for metric in metrics:
+        # todo: parallelize
+        yhat_train = [col for col in fcst_train.columns if "yhat" in col]
+        yhat_test = [col for col in fcst_test.columns if "yhat" in col]
+        n_yhats_train = len(yhat_train)
+        n_yhats_test = len(yhat_test)
+
+        assert n_yhats_train == n_yhats_test, "Dimensions of fcst dataframe faulty."
+
+        metric_train_list = []
+        metric_test_list = []
+
+        fcst_train = fcst_train.fillna(value=np.nan)
+        fcst_test = fcst_test.fillna(value=np.nan)
+
+        for x in range(1, n_yhats_train + 1):
+            metric_train_list.append(
+                ERROR_FUNCTIONS[metric](
+                    predictions=fcst_train["yhat{}".format(x)].values,
+                    truth=fcst_train["y"].values,
+                    truth_train=fcst_train["y"].values,
+                )
+            )
+            metric_test_list.append(
+                ERROR_FUNCTIONS[metric](
+                    predictions=fcst_test["yhat{}".format(x)].values,
+                    truth=fcst_test["y"].values,
+                    truth_train=fcst_train["y"].values,
+                )
+            )
+        result_train[metric] = np.nanmean(metric_train_list, dtype="float32")
+        result_test[metric] = np.nanmean(metric_test_list, dtype="float32")
+
+    return result_train, result_test

--- a/tot/exp_utils.py
+++ b/tot/exp_utils.py
@@ -1,6 +1,4 @@
 import logging
-import math
-from typing import List, Tuple
 
 import numpy as np
 

--- a/tot/exp_utils.py
+++ b/tot/exp_utils.py
@@ -8,6 +8,28 @@ log = logging.getLogger("tot.exp_utils")
 
 
 def evaluate_forecast(fcst_train, fcst_test, metrics, metadata=None):
+    """
+    Evaluate forecast performance on training and test data using specified metrics.
+
+    Parameters
+    ----------
+    fcst_train : pandas.DataFrame
+        Forecast data on the training set.
+    fcst_test : pandas.DataFrame
+        Forecast data on the test set.
+    metrics : list
+        List of error metrics to evaluate the forecast.
+    metadata : dict
+        Metadata to be stored in the results.
+
+    Returns
+    -------
+    result_train : pandas.DataFrame
+        Result of evaluation on training set.
+    result_test : pandas.DataFrame
+        Result of evaluation on test set.
+    """
+
     result_train = metadata.copy()
     result_test = metadata.copy()
 

--- a/tot/experiment.py
+++ b/tot/experiment.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from multiprocessing.pool import Pool
 from typing import List, Optional
 
-import numpy as np
 import pandas as pd
 from neuralprophet import set_random_seed
 

--- a/tot/experiment.py
+++ b/tot/experiment.py
@@ -43,7 +43,6 @@ class Experiment(ABC):
     num_processes: int = 1
 
     def __post_init__(self):
-
         data_params = {}
         if len(self.data.seasonalities) > 0:
             data_params["seasonalities"] = self.data.seasonalities

--- a/tot/models_naive.py
+++ b/tot/models_naive.py
@@ -83,7 +83,6 @@ class SeasonalNaiveModel(Model):
         assert (
             self.season_length > 1
         ), "season_length must be >1 for SeasonalNaiveModel. For season_length=1 select NaiveModel instead."
-        self.n_lags = None  # TODO: should not be set to None. Find different solution.
 
     def fit(self, df: pd.DataFrame, freq: str):
         pass

--- a/tot/models_simple.py
+++ b/tot/models_simple.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from tot.df_utils import _check_min_df_len, add_first_inputs_to_df, drop_first_inputs_from_df, prep_or_copy_df
 from tot.models import Model
-from tot.utils import _get_seasons, _predict_linear_regression, convert_df_to_TimeSeries
+from tot.utils import _get_seasons, _predict_darts_model, convert_df_to_TimeSeries
 
 log = logging.getLogger("tot.model")
 
@@ -205,7 +205,9 @@ class LinearRegressionModel(Model):
         if df_historic is not None:
             df = self.maybe_extend_df(df_historic, df)
         df, received_ID_col, received_single_time_series, _ = prep_or_copy_df(df)
-        fcst_df = _predict_linear_regression(model=self, df=df)
+        fcst_df = _predict_darts_model(
+            df=df, model=self, n_req_past_obs=self.n_lags, n_req_future_obs=self.n_forecasts, retrain=False
+        )
 
         if df_historic is not None:
             fcst_df, df = self.maybe_drop_added_values_from_df(fcst_df, df)


### PR DESCRIPTION
🔬 Background
We want to structure our framework in a way that the whole benchmarking pipeline is built upon modular functions. Modular functions can be called individually, which means outside of the benchmarking procedure. That offers the user the option to set up a customized experiment from scratch by using the modular function. To allow a modular function structure the predict step and evaluation step needs to be separated. 

🔮 Key changes
* introduce new modular function `evaluate_forecast()`. 
* Create a wrapper method in the experiment class for predicting `_make_forecast() `and for `evaluating _evaluate_model()`. 
* Additionally, save the forecast of each experiment in the benchmark output. 

📋 Review Checklist
- [x]  I have performed a self-review of my own code.
- [x]  I have commented my code, added docstrings and data types to function definitions.
- [x] No pytests needed.