### PR TITLE
Plot function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,3 +3,4 @@ neuralprophet>=0.3.2
 numpy>=1.15.4
 pandas>=1.0.4
 darts>= 0.23.1
+arrow>=1.2.3

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -124,7 +124,7 @@ def test_2_benchmark_CV():
         # plt_air = air_passengers.plot(x='model', y='RMSE', kind='barh')
         # data plot
         air_passengers = results_summary[results_summary["split"] == "test"]
-        air_passengers.plot(x="data", y="MASE", kind="barh")
+        # air_passengers.plot(x="data", y="MASE", kind="barh")
         plt.show()
 
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -66,6 +66,13 @@ def test_basic_plot(plotting_backend):
     results_train, results_test = benchmark.run()
     log.debug(results_test.to_string())
     fig = plot_plotly(benchmark.fcst_test[0], plotting_backend=plotting_backend)
+
+    with pytest.raises(ValueError):
+        # invalid plotting backend
+        plot_plotly(benchmark.fcst_test[0], plotting_backend="wrong_input")
+        # highlight_forecast out of range
+        plot_plotly(benchmark.fcst_test[0], highlight_forecast=5)
+
     if PLOT:
         fig.show()
     log.info("#### Done with test_basic_plot")

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -12,7 +12,7 @@ from tot.evaluation.metrics import ERROR_FUNCTIONS
 from tot.models.models_naive import NaiveModel, SeasonalNaiveModel
 from tot.models.models_neuralprophet import NeuralProphetModel
 from tot.models.models_simple import LinearRegressionModel, ProphetModel
-from tot.plot import plot
+from tot.plotting import plot_plotly
 
 log = logging.getLogger("tot.test")
 log.setLevel("WARNING")
@@ -65,7 +65,7 @@ def test_basic_plot(plotting_backend):
 
     results_train, results_test = benchmark.run()
     log.debug(results_test.to_string())
-    fig = plot(benchmark.fcst_test[0], plotting_backend=plotting_backend)
+    fig = plot_plotly(benchmark.fcst_test[0], plotting_backend=plotting_backend)
     if PLOT:
         fig.show()
     log.info("#### Done with test_basic_plot")

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -36,7 +36,7 @@ ERCOT_REGIONS = ["NORTH", "EAST", "FAR_WEST"]
 PLOT = False
 
 # plot tests cover both plotting backends
-decorator_input = ["plotting_backend", ["plotly-auto", "plotly", "plotly-resampler"]]
+decorator_input = ["plotting_backend", [None, "plotly", "plotly-resampler"]]
 
 
 @pytest.mark.parametrize(*decorator_input)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+import logging
+import os
+import pathlib
+
+import pandas as pd
+import pytest
+
+from tot.benchmark import SimpleBenchmark
+from tot.datasets.dataset import Dataset
+from tot.evaluation.metrics import ERROR_FUNCTIONS
+from tot.models.models_naive import NaiveModel, SeasonalNaiveModel
+from tot.models.models_neuralprophet import NeuralProphetModel
+from tot.models.models_simple import LinearRegressionModel, ProphetModel
+from tot.plot import plot
+
+log = logging.getLogger("tot.test")
+log.setLevel("WARNING")
+log.parent.setLevel("WARNING")
+
+DIR = pathlib.Path(__file__).parent.parent.absolute()
+DATA_DIR = os.path.join(DIR, "datasets")
+PEYTON_FILE = os.path.join(DATA_DIR, "wp_log_peyton_manning.csv")
+AIR_FILE = os.path.join(DATA_DIR, "air_passengers.csv")
+ERCOT_FILE = os.path.join(DATA_DIR, "ercot_load_reduced.csv")
+SAVE_DIR = os.path.join(DIR, "tests", "test-logs")
+if not os.path.isdir(SAVE_DIR):
+    os.makedirs(SAVE_DIR)
+
+
+NROWS = 128
+EPOCHS = 2
+BATCH_SIZE = 64
+LR = 1.0
+ERCOT_REGIONS = ["NORTH", "EAST", "FAR_WEST"]
+PLOT = False
+
+# plot tests cover both plotting backends
+decorator_input = ["plotting_backend", ["plotly-auto", "plotly", "plotly-resampler"]]
+
+
+@pytest.mark.parametrize(*decorator_input)
+def test_basic_plot(plotting_backend):
+    log.info("test_basic_plot")
+    air_passengers_df = pd.read_csv(AIR_FILE, nrows=NROWS)
+    dataset_list = [
+        Dataset(df=air_passengers_df, name="air_passengers", freq="MS"),
+    ]
+    model_classes_and_params = [
+        (NeuralProphetModel, {"n_forecasts": 4, "n_lags": 3, "epochs": 1}),
+        (NaiveModel, {"n_forecasts": 4}),
+        (SeasonalNaiveModel, {"n_forecasts": 4, "season_length": 12}),
+        (ProphetModel, {}),
+        (LinearRegressionModel, {"lags": 12, "output_chunk_length": 1, "n_forecasts": 4}),
+    ]
+
+    benchmark = SimpleBenchmark(
+        model_classes_and_params=model_classes_and_params,
+        datasets=dataset_list,
+        metrics=list(ERROR_FUNCTIONS.keys()),
+        test_percentage=0.25,
+        save_dir=SAVE_DIR,
+        num_processes=1,
+    )
+
+    results_train, results_test = benchmark.run()
+    log.debug(results_test.to_string())
+    fig = plot(benchmark.fcst_test[0], plotting_backend=plotting_backend)
+    if PLOT:
+        fig.show()
+    log.info("#### Done with test_basic_plot")

--- a/tot/plot.py
+++ b/tot/plot.py
@@ -36,9 +36,9 @@ def plot(
             optional, Label name on X-axis
         ylabel : str
             optional, Label name on Y-axis
-        highlight_forecast : int
+        highlight_forecast : Union[int, None]
             optional, i-th step ahead forecast to highlight.
-        figsize : tuple
+        figsize : tuple[int, int]
             optional, Width, height in inches.
         plotting_backend : str
             optional, overwrites the default plotting backend.

--- a/tot/plot.py
+++ b/tot/plot.py
@@ -69,5 +69,5 @@ def plot(
         ylabel=ylabel,
         highlight_forecast=highlight_forecast,
         figsize=figsize,
-        resampler_active=plotting_backend == "plotly-resampler",
+        resampler_active=True if plotting_backend == "plotly-resampler" else False,
     )

--- a/tot/plot.py
+++ b/tot/plot.py
@@ -1,0 +1,73 @@
+import logging
+from typing import Union
+
+import pandas as pd
+
+from tot.plot_utils import (
+    _plot_plotly,
+    auto_set_plotting_backend,
+    validate_df_name_input,
+    validate_highlight_forecast_input,
+    validate_plotting_backend_input,
+)
+
+log = logging.getLogger("tot.plot")
+
+
+def plot(
+    fcst: pd.DataFrame,
+    df_name: str = None,
+    xlabel: str = "ds",
+    ylabel: str = "y",
+    highlight_forecast: Union[int, None] = None,
+    figsize: tuple[int, int] = (700, 350),
+    plotting_backend: str = "plotly-auto",
+):
+    """
+    Plot the NeuralProphet forecast
+
+    Parameters
+    ---------
+        fcst : pd.DataFrame
+            Output of m.predict
+        df_name : str
+            optoinal, ID from time series that should be plotted
+        xlabel : str
+            optional, Label name on X-axis
+        ylabel : str
+            optional, Label name on Y-axis
+        highlight_forecast : int
+            optional, i-th step ahead forecast to highlight.
+        figsize : tuple
+            optional, Width, height in inches.
+        plotting_backend : str
+            optional, overwrites the default plotting backend.
+
+            Options
+            * ``plotly-resampler``: Use the plotly backend for plotting in resample mode. This mode uses the
+                plotly-resampler package to accelerate visualizing large data by resampling it. For some
+                environments (colab, pycharm interpreter) plotly-resampler might not properly visualize the figures.
+                In this case, consider switching to 'plotly-auto'.
+            * ``plotly``: Use the plotly package for plotting
+            * (default) ``plotly-auto``: Use plotly with resampling for jupyterlab notebooks and vscode notebooks.
+                Automatically switch to plotly without resampling for all other environments.
+
+    Returns
+    -------
+        Plotly figure
+    """
+    # input check
+    fcst = validate_df_name_input(df_name, fcst)
+    validate_highlight_forecast_input(highlight_forecast, fcst)
+    validate_plotting_backend_input(plotting_backend)
+    # Set internal plotting backend
+    plotting_backend = auto_set_plotting_backend(plotting_backend)
+    return _plot_plotly(
+        fcst=fcst,
+        quantiles=[0.5],  # set default to median quantile
+        xlabel=xlabel,
+        ylabel=ylabel,
+        highlight_forecast=highlight_forecast,
+        figsize=figsize,
+        resampler_active=plotting_backend == "plotly-resampler",
+    )

--- a/tot/plot_utils.py
+++ b/tot/plot_utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Union
+from typing import Union, Tuple
 
 import numpy as np
 import pandas as pd
@@ -226,13 +226,13 @@ def validate_df_name_input(df_name: str, fcst: pd.DataFrame):
 
 
 def _plot_plotly(
-    fcst: pd.DataFrame,
-    quantiles: list = [0.5],
-    xlabel: str = "ds",
-    ylabel: str = "y",
-    highlight_forecast: Union[int, None] = None,
-    figsize: tuple[int, int] = (700, 350),
-    resampler_active: bool = False,
+    fcst,
+    quantiles=[0.5],
+    xlabel="ds",
+    ylabel="y",
+    highlight_forecast=None,
+    figsize=(700, 350),
+    resampler_active=False,
 ):
     """
     Plot the NeuralProphet forecast

--- a/tot/plot_utils.py
+++ b/tot/plot_utils.py
@@ -210,9 +210,8 @@ def validate_df_name_input(df_name, fcst):
             assert (
                 len(fcst["ID"].unique()) > 1
             ), "Many time series are present in the pd.DataFrame (more than one ID). Please, especify ID to be plotted."
-        else:
-            fcst = fcst[fcst["ID"] == df_name].copy(deep=True)
-            log.info(f"Plotting data from ID {df_name}")
+        fcst = fcst[fcst["ID"] == df_name].copy(deep=True)
+        log.info(f"Plotting data from ID {df_name}")
     return fcst
 
 

--- a/tot/plot_utils.py
+++ b/tot/plot_utils.py
@@ -1,7 +1,6 @@
 import logging
 
 import numpy as np
-import pandas as pd
 import plotly.graph_objs as go
 from plotly_resampler import register_plotly_resampler, unregister_plotly_resampler
 

--- a/tot/plot_utils.py
+++ b/tot/plot_utils.py
@@ -3,13 +3,13 @@ from typing import Union
 
 import numpy as np
 import pandas as pd
+import plotly.graph_objs as go
+from plotly_resampler import register_plotly_resampler, unregister_plotly_resampler
 
 from tot.df_utils import prep_or_copy_df
 
 log = logging.getLogger("tot.plot")
 
-import plotly.graph_objs as go
-from plotly_resampler import register_plotly_resampler, unregister_plotly_resampler
 
 # UI Configuration
 prediction_color = "#2d92ff"

--- a/tot/plot_utils.py
+++ b/tot/plot_utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Union, Tuple
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -160,7 +160,7 @@ def validate_plotting_backend_input(plotting_backend: str):
         log_value_error_invalid_plotting_backend_input()
 
 
-def validate_highlight_forecast_input(highlight_forecast: int, fcst: pd.DataFrame):
+def validate_highlight_forecast_input(highlight_forecast: Optional[int], fcst: pd.DataFrame):
     """
     Validate the input argument for the highlight_forecast.
 
@@ -189,7 +189,7 @@ def validate_highlight_forecast_input(highlight_forecast: int, fcst: pd.DataFram
         log_value_error_invalid_highlight_forecast_input()
 
 
-def validate_df_name_input(df_name: str, fcst: pd.DataFrame):
+def validate_df_name_input(df_name: Optional[str], fcst: pd.DataFrame):
     """
     Validate the input df_name and returns a dataframe with a single time series and an ID.
 

--- a/tot/plot_utils.py
+++ b/tot/plot_utils.py
@@ -37,20 +37,6 @@ layout_args = {
 }
 
 
-# def log_warning_colab_resampler():
-#     log.warning(
-#         "Warning: plotly-resampler not supported for google colab environment. "
-#         "Plotting backend automatically switched to 'plotly' without resampling "
-#     )
-#
-#
-# def log_warning_static_env_resampler():
-#     log.warning(
-#         "Warning: plotly-resampler not supported for this environments. "
-#         "Plotting backend automatically switched to 'plotly' without resampling "
-#     )
-
-
 def log_value_error_invalid_plotting_backend_input():
     raise ValueError(
         "Selected plotting backend invalid. Set plotting backend to one of the "
@@ -77,30 +63,6 @@ def log_warning_resampler_switch_to_valid_env():
         "Warning: plotly-resampler not supported for the environment you are using. "
         "Plotting backend automatically switched to 'plotly' without resampling "
     )
-
-
-# def validate_current_env():
-#     """
-#     Validate the current environment to check if it is a valid environment to run the code.
-#
-#     Returns
-#     -------
-#     bool :
-#         True if the current environment is a valid environment to run the code, False otherwise.
-#
-#     """
-#     from IPython.core.getipython import get_ipython
-#
-#     if "google.colab" in str(get_ipython()):
-#         log_warning_colab_resampler()
-#         return False
-#     else:
-#         if is_notebook():
-#             vaild_env = True
-#         else:
-#             log_warning_static_env_resampler()
-#             vaild_env = False
-#     return vaild_env
 
 
 def validate_current_env_for_resampler(auto: bool = False) -> Optional[bool]:

--- a/tot/plot_utils.py
+++ b/tot/plot_utils.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -110,7 +109,7 @@ def is_notebook():
     return True
 
 
-def auto_set_plotting_backend(plotting_backend_original: str):
+def auto_set_plotting_backend(plotting_backend_original):
     """
     Automatically set the plotting backend.
 
@@ -135,7 +134,7 @@ def auto_set_plotting_backend(plotting_backend_original: str):
     return plotting_backend_new
 
 
-def validate_plotting_backend_input(plotting_backend: str):
+def validate_plotting_backend_input(plotting_backend):
     """
     Validate the input argument for the plotting backend.
 
@@ -160,7 +159,7 @@ def validate_plotting_backend_input(plotting_backend: str):
         log_value_error_invalid_plotting_backend_input()
 
 
-def validate_highlight_forecast_input(highlight_forecast: Optional[int], fcst: pd.DataFrame):
+def validate_highlight_forecast_input(highlight_forecast, fcst):
     """
     Validate the input argument for the highlight_forecast.
 
@@ -189,7 +188,7 @@ def validate_highlight_forecast_input(highlight_forecast: Optional[int], fcst: p
         log_value_error_invalid_highlight_forecast_input()
 
 
-def validate_df_name_input(df_name: Optional[str], fcst: pd.DataFrame):
+def validate_df_name_input(df_name, fcst):
     """
     Validate the input df_name and returns a dataframe with a single time series and an ID.
 

--- a/tot/plot_utils.py
+++ b/tot/plot_utils.py
@@ -205,7 +205,7 @@ def validate_df_name_input(df_name, fcst):
 
     Raises
     ------
-    Exception
+    AssertionError
         If the input DataFrame contains more than one time series and the df_name argument is not provided, or if the
         specified df_name is not present in the DataFrame.
 
@@ -213,10 +213,9 @@ def validate_df_name_input(df_name, fcst):
     fcst, received_ID_col, received_single_time_series, _ = prep_or_copy_df(fcst)
     if not received_single_time_series:
         if df_name not in fcst["ID"].unique():
-            assert len(fcst["ID"].unique()) > 1
-            raise Exception(
-                "Many time series are present in the pd.DataFrame (more than one ID). Please, especify ID to be plotted."
-            )
+            assert (
+                len(fcst["ID"].unique()) > 1
+            ), "Many time series are present in the pd.DataFrame (more than one ID). Please, especify ID to be plotted."
         else:
             fcst = fcst[fcst["ID"] == df_name].copy(deep=True)
             log.info(f"Plotting data from ID {df_name}")

--- a/tot/plot_utils.py
+++ b/tot/plot_utils.py
@@ -77,7 +77,7 @@ def validate_current_env():
 
     if "google.colab" in str(get_ipython()):
         log_warning_colab_resampler()
-        vaild_env = False
+        return False
     else:
         if is_notebook():
             vaild_env = True

--- a/tot/plot_utils.py
+++ b/tot/plot_utils.py
@@ -1,0 +1,376 @@
+import logging
+from typing import Union
+
+import numpy as np
+import pandas as pd
+
+from tot.df_utils import prep_or_copy_df
+
+log = logging.getLogger("tot.plot")
+
+import plotly.graph_objs as go
+from plotly_resampler import register_plotly_resampler, unregister_plotly_resampler
+
+# UI Configuration
+prediction_color = "#2d92ff"
+actual_color = "black"
+trend_color = "#B23B00"
+line_width = 2
+marker_size = 4
+xaxis_args = {
+    "showline": True,
+    "mirror": True,
+    "linewidth": 1.5,
+}
+yaxis_args = {
+    "showline": True,
+    "mirror": True,
+    "linewidth": 1.5,
+}
+layout_args = {
+    "autosize": True,
+    "template": "plotly_white",
+    "margin": go.layout.Margin(l=0, r=10, b=0, t=10, pad=0),
+    "font": dict(size=10),
+    "title": dict(font=dict(size=12)),
+    "hovermode": "x unified",
+}
+
+
+def log_warning_colab_resampler():
+    log.warning(
+        "Warning: plotly-resampler not supported for google colab environment. "
+        "Plotting backend automatically switched to 'plotly' without resampling "
+    )
+
+
+def log_warning_static_env_resampler():
+    log.warning(
+        "Warning: plotly-resampler not supported for this environments. "
+        "Plotting backend automatically switched to 'plotly' without resampling "
+    )
+
+
+def log_value_error_invalid_plotting_backend_input():
+    raise ValueError(
+        "Selected plotting backend invalid. Set plotting backend to one of the "
+        "valid options 'plotly','plotly-auto','plotly-resampler'."
+    )
+
+
+def log_value_error_invalid_highlight_forecast_input():
+    raise ValueError(
+        "input for highlight_forecast invalid. Set highlight_forecast step equal to"
+        " or smaller than the prediction horizon"
+    )
+
+
+def validate_current_env():
+    """
+    Validate the current environment to check if it is a valid environment to run the code.
+
+    Returns
+    -------
+    bool :
+        True if the current environment is a valid environment to run the code, False otherwise.
+
+    """
+    from IPython.core.getipython import get_ipython
+
+    if "google.colab" in str(get_ipython()):
+        log_warning_colab_resampler()
+        vaild_env = False
+    else:
+        if is_notebook():
+            vaild_env = True
+        else:
+            log_warning_static_env_resampler()
+            vaild_env = False
+    return vaild_env
+
+
+def is_notebook():
+    """
+    Determine if the code is being executed in a Jupyter notebook environment.
+
+    Returns
+    -------
+    bool :
+        True if the code is being executed in a Jupyter notebook, False otherwise.
+    """
+    try:
+        from IPython.core.getipython import get_ipython
+
+        if "IPKernelApp" not in str(get_ipython()):  # pragma: no cover
+            return False
+    except ImportError:
+        return False
+    except AttributeError:
+        return False
+    return True
+
+
+def auto_set_plotting_backend(plotting_backend_original: str):
+    """
+    Automatically set the plotting backend.
+
+    Given `plotting_backend_original`, returns "plotly-resample" if `validate_current_env()`
+    returns `True` and `plotting_backend_original` is "plotly-auto", "plotly" otherwise. If
+    `plotting_backend_original` is not "plotly-auto", returns `plotting_backend_original`.
+
+    Parameters
+    ----------
+    plotting_backend_original : str
+        Original plotting backend.
+
+    Returns
+    -------
+    str
+        The new plotting backend.
+    """
+    if plotting_backend_original == "plotly-auto":
+        plotting_backend_new = "plotly-resample" if validate_current_env() else "plotly"
+    else:
+        plotting_backend_new = plotting_backend_original
+    return plotting_backend_new
+
+
+def validate_plotting_backend_input(plotting_backend: str):
+    """
+    Validate the input argument for the plotting backend.
+
+    Parameters
+    ----------
+    plotting_backend:str
+        The name of the plotting backend.
+
+    Raises
+    ----------
+    ValueError:
+        If the plotting backend is not a valid backend.
+
+    Returns
+    ----------
+        None
+    """
+    valid_plotting_backends = ["plotly", "plotly-auto", "plotly-resampler"]
+    if plotting_backend in valid_plotting_backends:
+        pass
+    else:
+        log_value_error_invalid_plotting_backend_input()
+
+
+def validate_highlight_forecast_input(highlight_forecast: int, fcst: pd.DataFrame):
+    """
+    Validate the input argument for the highlight_forecast.
+
+    Parameters
+    ----------
+    highlight_forecast : int
+        The number of forecasts to highlight.
+    fcst : pd.DataFrame
+        The forecast DataFrame.
+
+    Raises
+    ------
+    ValueError
+        If the highlight_forecast value is greater than the number of yhat (prediction horizon) columns in fcst.
+
+    Returns
+    -------
+    None
+    """
+    n_yhat = len([col for col in fcst.columns if "yhat" in col])
+    if highlight_forecast is None:
+        pass
+    elif highlight_forecast <= n_yhat:
+        pass
+    else:
+        log_value_error_invalid_highlight_forecast_input()
+
+
+def validate_df_name_input(df_name: str, fcst: pd.DataFrame):
+    """
+    Validate the input df_name and returns a dataframe with a single time series and an ID.
+
+    Parameters
+    ----------
+    df_name : str
+        optoinal, ID from time series that should be plotted
+    fcst : pd.DataFrame
+        forecast dataframe
+
+    Returns
+    -------
+    pd.DataFrame
+        A copy of the input dataframe containing the time series data for the specified name.
+
+    Raises
+    ------
+    Exception
+        If the input DataFrame contains more than one time series and the df_name argument is not provided, or if the
+        specified df_name is not present in the DataFrame.
+
+    """
+    fcst, received_ID_col, received_single_time_series, _ = prep_or_copy_df(fcst)
+    if not received_single_time_series:
+        if df_name not in fcst["ID"].unique():
+            assert len(fcst["ID"].unique()) > 1
+            raise Exception(
+                "Many time series are present in the pd.DataFrame (more than one ID). Please, especify ID to be plotted."
+            )
+        else:
+            fcst = fcst[fcst["ID"] == df_name].copy(deep=True)
+            log.info(f"Plotting data from ID {df_name}")
+    return fcst
+
+
+def _plot_plotly(
+    fcst: pd.DataFrame,
+    quantiles: list = [0.5],
+    xlabel: str = "ds",
+    ylabel: str = "y",
+    highlight_forecast: Union[int, None] = None,
+    figsize: tuple[int, int] = (700, 350),
+    resampler_active: bool = False,
+):
+    """
+    Plot the NeuralProphet forecast
+
+    Parameters
+    ---------
+        fcst : pd.DataFrame
+            Output of m.predict
+        quantiles: list
+            Quantiles for which the forecasts are to be plotted.
+        xlabel : str
+            Label name on X-axis
+        ylabel : str
+            Label name on Y-axis
+        highlight_forecast : Union[int, None]
+            i-th step ahead forecast to highlight.
+        line_per_origin : bool
+            Print a line per forecast of one per forecast age
+        figsize : tuple [int, int]
+            Width, height in inches.
+
+    Returns
+    -------
+        Plotly figure
+    """
+    if resampler_active:
+        register_plotly_resampler(mode="auto")
+    else:
+        unregister_plotly_resampler()
+    cross_marker_color = "blue"
+    cross_symbol = "x"
+
+    fcst = fcst.fillna(value=np.nan)
+
+    ds = fcst["ds"].dt.to_pydatetime()
+    colname = "yhat"
+    step = 1
+    # all yhat column names, including quantiles
+    yhat_col_names = [col_name for col_name in fcst.columns if f"{colname}" in col_name]
+    # without quants
+    yhat_col_names_no_qts = [
+        col_name for col_name in yhat_col_names if f"{colname}" in col_name and "%" not in col_name
+    ]
+    data = []
+
+    if highlight_forecast is None:
+        for i, yhat_col_name in enumerate(yhat_col_names_no_qts):
+            data.append(
+                go.Scatter(
+                    name=yhat_col_name,
+                    x=ds,
+                    y=fcst[f"{colname}{i + 1}"],
+                    mode="lines",
+                    line=dict(color=f"rgba(45, 146, 255, {0.2 + 2.0 / (i + 2.5)})", width=line_width),
+                    fill="none",
+                )
+            )
+    if len(quantiles) > 1:
+        for i in range(1, len(quantiles)):
+            # skip fill="tonexty" for the first quantile
+            if i == 1:
+                data.append(
+                    go.Scatter(
+                        name=f"{colname}{highlight_forecast if highlight_forecast else step} {round(quantiles[i] * 100, 1)}%",
+                        x=ds,
+                        y=fcst[
+                            f"{colname}{highlight_forecast if highlight_forecast else step} {round(quantiles[i] * 100, 1)}%"
+                        ],
+                        mode="lines",
+                        line=dict(color="rgba(45, 146, 255, 0.2)", width=1),
+                        fillcolor="rgba(45, 146, 255, 0.2)",
+                    )
+                )
+            else:
+                data.append(
+                    go.Scatter(
+                        name=f"{colname}{highlight_forecast if highlight_forecast else step} {round(quantiles[i] * 100, 1)}%",
+                        x=ds,
+                        y=fcst[
+                            f"{colname}{highlight_forecast if highlight_forecast else step} {round(quantiles[i] * 100, 1)}%"
+                        ],
+                        mode="lines",
+                        line=dict(color="rgba(45, 146, 255, 0.2)", width=1),
+                        fill="tonexty",
+                        fillcolor="rgba(45, 146, 255, 0.2)",
+                    )
+                )
+
+    if highlight_forecast is not None:
+        x = ds
+        y = fcst[f"yhat{highlight_forecast}"]
+        data.append(
+            go.Scatter(
+                name="Predicted",
+                x=x,
+                y=y,
+                mode="lines",
+                line=dict(color=prediction_color, width=line_width),
+            )
+        )
+        data.append(
+            go.Scatter(
+                name="Predicted",
+                x=x,
+                y=y,
+                mode="markers",
+                marker=dict(color=cross_marker_color, size=marker_size, symbol=cross_symbol),
+            )
+        )
+
+    # Add actual
+    data.append(
+        go.Scatter(name="Actual", x=ds, y=fcst["y"], marker=dict(color=actual_color, size=marker_size), mode="markers")
+    )
+
+    layout = go.Layout(
+        showlegend=True,
+        width=figsize[0],
+        height=figsize[1],
+        xaxis=go.layout.XAxis(
+            title=xlabel,
+            type="date",
+            rangeselector=dict(
+                buttons=list(
+                    [
+                        dict(count=7, label="1w", step="day", stepmode="backward"),
+                        dict(count=1, label="1m", step="month", stepmode="backward"),
+                        dict(count=6, label="6m", step="month", stepmode="backward"),
+                        dict(count=1, label="1y", step="year", stepmode="backward"),
+                        dict(step="all"),
+                    ]
+                )
+            ),
+            rangeslider=dict(visible=True),
+            **xaxis_args,
+        ),
+        yaxis=go.layout.YAxis(title=ylabel, **yaxis_args),
+        **layout_args,
+    )
+    fig = go.Figure(data=data, layout=layout)
+    return fig

--- a/tot/plot_utils.py
+++ b/tot/plot_utils.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional
 
+import arrow
 import numpy as np
 import plotly.graph_objs as go
 from plotly_resampler import register_plotly_resampler, unregister_plotly_resampler

--- a/tot/plot_utils.py
+++ b/tot/plot_utils.py
@@ -232,7 +232,7 @@ def _plot_plotly(
     ylabel: str = "y",
     highlight_forecast: Union[int, None] = None,
     figsize: tuple[int, int] = (700, 350),
-    resampler_active: bool = False,
+    resampler_active=False,
 ):
     """
     Plot the NeuralProphet forecast

--- a/tot/plot_utils.py
+++ b/tot/plot_utils.py
@@ -232,7 +232,7 @@ def _plot_plotly(
     ylabel: str = "y",
     highlight_forecast: Union[int, None] = None,
     figsize: tuple[int, int] = (700, 350),
-    resampler_active=False,
+    resampler_active: bool = False,
 ):
     """
     Plot the NeuralProphet forecast

--- a/tot/plotting.py
+++ b/tot/plotting.py
@@ -16,12 +16,12 @@ log = logging.getLogger("tot.plot")
 
 def plot_plotly(
     fcst: pd.DataFrame,
-    df_name: Optional[str] = None,
-    xlabel: str = "ds",
-    ylabel: str = "y",
+    df_name=None,
+    xlabel="ds",
+    ylabel="y",
     highlight_forecast: Optional[int] = None,
     figsize: tuple[int, int] = (700, 350),
-    plotting_backend: str = "plotly-auto",
+    plotting_backend="plotly-auto",
 ):
     """
     Plot the NeuralProphet forecast

--- a/tot/plotting.py
+++ b/tot/plotting.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 import pandas as pd
 
@@ -15,12 +16,12 @@ log = logging.getLogger("tot.plot")
 
 def plot_plotly(
     fcst: pd.DataFrame,
-    df_name=None,
-    xlabel="ds",
-    ylabel="y",
-    highlight_forecast=None,
-    figsize=(700, 350),
-    plotting_backend="plotly-auto",
+    df_name: Optional[str] = None,
+    xlabel: str = "ds",
+    ylabel: str = "y",
+    highlight_forecast: Optional[int] = None,
+    figsize: tuple[int, int] = (700, 350),
+    plotting_backend: str = "plotly-auto",
 ):
     """
     Plot the NeuralProphet forecast

--- a/tot/plotting.py
+++ b/tot/plotting.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 
 import pandas as pd
 
@@ -16,11 +15,11 @@ log = logging.getLogger("tot.plot")
 
 def plot_plotly(
     fcst: pd.DataFrame,
-    df_name: Optional[str] = None,
-    xlabel: str = "ds",
-    ylabel: str = "y",
-    highlight_forecast: Optional[int] = None,
-    figsize: tuple[int, int] = (700, 350),
+    df_name=None,
+    xlabel="ds",
+    ylabel="y",
+    highlight_forecast=None,
+    figsize=(700, 350),
     plotting_backend="plotly-auto",
 ):
     """

--- a/tot/plotting.py
+++ b/tot/plotting.py
@@ -1,7 +1,4 @@
 import logging
-from typing import Optional
-
-import pandas as pd
 
 from tot.plot_utils import (
     _plot_plotly,
@@ -15,12 +12,12 @@ log = logging.getLogger("tot.plot")
 
 
 def plot_plotly(
-    fcst: pd.DataFrame,
+    fcst,
     df_name=None,
     xlabel="ds",
     ylabel="y",
-    highlight_forecast: Optional[int] = None,
-    figsize: tuple[int, int] = (700, 350),
+    highlight_forecast=None,
+    figsize=(700, 350),
     plotting_backend="plotly-auto",
 ):
     """

--- a/tot/plotting.py
+++ b/tot/plotting.py
@@ -2,7 +2,7 @@ import logging
 
 from tot.plot_utils import (
     _plot_plotly,
-    auto_set_plotting_backend,
+    select_plotting_backend,
     validate_df_name_input,
     validate_highlight_forecast_input,
     validate_plotting_backend_input,
@@ -18,7 +18,7 @@ def plot_plotly(
     ylabel="y",
     highlight_forecast=None,
     figsize=(700, 350),
-    plotting_backend="plotly-auto",
+    plotting_backend=None,
 ):
     """
     Plot the NeuralProphet forecast
@@ -46,7 +46,7 @@ def plot_plotly(
                 environments (colab, pycharm interpreter) plotly-resampler might not properly visualize the figures.
                 In this case, consider switching to 'plotly-auto'.
             * ``plotly``: Use the plotly package for plotting
-            * (default) ``plotly-auto``: Use plotly with resampling for jupyterlab notebooks and vscode notebooks.
+            * (default) None: Use plotly with resampling for jupyterlab notebooks and vscode notebooks.
                 Automatically switch to plotly without resampling for all other environments.
 
     Returns
@@ -57,8 +57,8 @@ def plot_plotly(
     fcst = validate_df_name_input(df_name, fcst)
     validate_highlight_forecast_input(highlight_forecast, fcst)
     validate_plotting_backend_input(plotting_backend)
-    # Set internal plotting backend
-    plotting_backend = auto_set_plotting_backend(plotting_backend)
+    # Select internal plotting backend
+    plotting_backend = select_plotting_backend(plotting_backend)
     return _plot_plotly(
         fcst=fcst,
         quantiles=[0.5],  # set default to median quantile
@@ -66,5 +66,5 @@ def plot_plotly(
         ylabel=ylabel,
         highlight_forecast=highlight_forecast,
         figsize=figsize,
-        resampler_active=True if plotting_backend == "plotly-resampler" else False,
+        resampler_active=plotting_backend == "plotly-resampler",
     )

--- a/tot/plotting.py
+++ b/tot/plotting.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Union
+from typing import Optional
 
 import pandas as pd
 
@@ -16,12 +16,12 @@ log = logging.getLogger("tot.plot")
 
 def plot_plotly(
     fcst: pd.DataFrame,
-    df_name: str = None,
+    df_name: Optional[str] = None,
     xlabel: str = "ds",
     ylabel: str = "y",
-    highlight_forecast: Union[int, None] = None,
+    highlight_forecast: Optional[int] = None,
     figsize: tuple[int, int] = (700, 350),
-    plotting_backend: str = "plotly-auto",
+    plotting_backend="plotly-auto",
 ):
     """
     Plot the NeuralProphet forecast

--- a/tot/plotting.py
+++ b/tot/plotting.py
@@ -14,7 +14,7 @@ from tot.plot_utils import (
 log = logging.getLogger("tot.plot")
 
 
-def plot(
+def plot_plotly(
     fcst: pd.DataFrame,
     df_name: str = None,
     xlabel: str = "ds",


### PR DESCRIPTION
🔬 Background
We want to enable plotting the forecasts of individual experiments

🔮 Key changes
- Implement a function `plot()` that take the `fcst_df` as an input (as well as further optional inputs) to plot the forecasts
-`plot()` is based on the plotly package and offers 3 plotting_backends: `plotly-auto`, `plotly`, `plotly-resampler` 
- either plot all forecast steps or specify single forecast step to plot with `highlight_forecast`
- example usage
`plot(benchmark.fcst_test[0], plotting_backend='plotly-auto')
 `

📋 Review Checklist

- [x] I have added pytests
- [x] I have added docstrings
- [x] I have added typing
- [x]  I have performed a self-review of my own code.