### PR TITLE
Add regressors for NeuralProphetModel

### DIFF
--- a/tests/test_regressors.py
+++ b/tests/test_regressors.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+import logging
+import os
+import pathlib
+
+import pandas as pd
+import pytest
+
+from tot.benchmark import SimpleBenchmark
+from tot.datasets.dataset import Dataset
+from tot.evaluation.metrics import ERROR_FUNCTIONS
+from tot.models.models_naive import NaiveModel, SeasonalNaiveModel
+from tot.models.models_neuralprophet import TorchProphetModel, NeuralProphetModel
+from tot.models.models_simple import LinearRegressionModel, ProphetModel
+
+log = logging.getLogger("tot.test")
+log.setLevel("WARNING")
+log.parent.setLevel("WARNING")
+
+DIR = pathlib.Path(__file__).parent.parent.absolute()
+DATA_DIR = os.path.join(DIR, "datasets")
+PEYTON_FILE = os.path.join(DATA_DIR, "wp_log_peyton_manning.csv")
+AIR_FILE = os.path.join(DATA_DIR, "air_passengers.csv")
+ERCOT_FILE = os.path.join(DATA_DIR, "ercot_load_reduced.csv")
+SAVE_DIR = os.path.join(DIR, "tests", "test-logs")
+if not os.path.isdir(SAVE_DIR):
+    os.makedirs(SAVE_DIR)
+
+
+NROWS = 128
+EPOCHS = 2
+BATCH_SIZE = 64
+LR = 1.0
+ERCOT_REGIONS = ["NORTH", "EAST", "FAR_WEST"]
+
+PLOT = False
+
+
+def test_lag_reg():
+    log.info(f"testing: Add lagged regressors to models")
+    peyton_manning_df = pd.read_csv(PEYTON_FILE, nrows=NROWS)
+    peyton_manning_df["A"] = peyton_manning_df["y"].rolling(7, min_periods=1).mean()
+    peyton_manning_df["B"] = peyton_manning_df["y"].rolling(30, min_periods=1).mean()
+    dataset_list = [
+        Dataset(df=peyton_manning_df, name="peyton_manning", freq="D"),
+    ]
+    model_classes_and_params = [
+        (
+            NeuralProphetModel,
+            {"n_lags": 3, "n_forecasts": 2, "epochs": 3, "lagged_regressors": ["A", "B"],},
+        ),
+    ]
+    log.debug("{}".format(model_classes_and_params))
+
+    benchmark = SimpleBenchmark(
+        model_classes_and_params=model_classes_and_params,
+        datasets=dataset_list,
+        metrics=list(ERROR_FUNCTIONS.keys()),
+        test_percentage=0.25,
+        save_dir=SAVE_DIR,
+        num_processes=1,
+    )
+    results_train, results_test = benchmark.run()
+    log.info("#### test_torch_prophet_model")
+    print(results_test)
+

--- a/tests/test_regressors.py
+++ b/tests/test_regressors.py
@@ -47,7 +47,7 @@ def test_lag_reg():
     model_classes_and_params = [
         (
             NeuralProphetModel,
-            {"n_lags": 3, "n_forecasts": 2, "epochs": 3, "lagged_regressors": ["A", "B"]},
+            {"n_lags": 3, "n_forecasts": 2, "epochs": 3, "lagged_regressors": {"A", "B"}},
         ),
         (
             NeuralProphetModel,
@@ -55,8 +55,7 @@ def test_lag_reg():
                 "n_lags": 3,
                 "n_forecasts": 2,
                 "epochs": 3,
-                "lagged_regressors": ["A", "B"],
-                "lagged_regressors_config": {
+                "lagged_regressors": {
                     "A": {"n_lags": 5, "regularization": 0.9, "normalize": False},
                     "B": {"n_lags": 5},
                 },
@@ -123,7 +122,7 @@ def test_future_reg():
                 "n_lags": 3,
                 "n_forecasts": 2,
                 "epochs": 3,
-                "future_regressors": ["A", "B"],
+                "future_regressors": {"A", "B"},
             },
         ),
         (
@@ -132,8 +131,7 @@ def test_future_reg():
                 "n_lags": 3,
                 "n_forecasts": 2,
                 "epochs": 3,
-                "future_regressors": ["A", "B"],
-                "future_regressors_config": {
+                "future_regressors": {
                     "A": {"mode": "multiplicative", "regularization": 0.9, "normalize": "auto"},
                     "B": {"mode": "multiplicative"},
                 },

--- a/tests/test_regressors.py
+++ b/tests/test_regressors.py
@@ -9,9 +9,7 @@ import pytest
 from tot.benchmark import SimpleBenchmark
 from tot.datasets.dataset import Dataset
 from tot.evaluation.metrics import ERROR_FUNCTIONS
-from tot.models.models_naive import NaiveModel, SeasonalNaiveModel
 from tot.models.models_neuralprophet import NeuralProphetModel, TorchProphetModel
-from tot.models.models_simple import LinearRegressionModel, ProphetModel
 
 log = logging.getLogger("tot.test")
 log.setLevel("WARNING")

--- a/tot/experiment.py
+++ b/tot/experiment.py
@@ -56,7 +56,13 @@ class Experiment(ABC):
             self.experiment_name = "{}_{}{}".format(
                 self.data.name,
                 self.model_class.model_name,
-                r"".join([r"_{0}_{1}".format(k, v) for k, v in self.params.items()]).replace("'", "").replace(":", "_"),
+                r"".join([r"_{0}_{1}".format(k, v) for k, v in self.params.items()])
+                .replace("'", "")
+                .replace(":", "_")
+                .replace("{", "_")
+                .replace("}", "_")
+                .replace("[", "_")
+                .replace("]", "_"),
             )
         if not hasattr(self, "metadata") or self.metadata is None:
             self.metadata = {
@@ -90,7 +96,7 @@ class Experiment(ABC):
         if current_fold is not None:
             name = name + "_fold_" + str(current_fold)
         name = prefix + "_" + name + ".csv"
-        df.to_csv(os.path.join(self.save_dir, name), encoding="utf-8", index=False)
+        df.to_csv(os.path.join(self.save_dir, name)[0:380], encoding="utf-8", index=False)
 
     def _make_forecast(
         self,

--- a/tot/experiment.py
+++ b/tot/experiment.py
@@ -96,7 +96,7 @@ class Experiment(ABC):
         if current_fold is not None:
             name = name + "_fold_" + str(current_fold)
         name = prefix + "_" + name + ".csv"
-        df.to_csv(os.path.join(self.save_dir, name)[0:380], encoding="utf-8", index=False)
+        df.to_csv(os.path.join(self.save_dir, name)[0:260], encoding="utf-8", index=False)
 
     def _make_forecast(
         self,

--- a/tot/models/models_neuralprophet.py
+++ b/tot/models/models_neuralprophet.py
@@ -28,9 +28,15 @@ class NeuralProphetModel(Model):
             self.params.update({"yearly_seasonality": yearly})
         if "seasonality_mode" in data_params and data_params["seasonality_mode"] is not None:
             self.params.update({"seasonality_mode": data_params["seasonality_mode"]})
+
         model_params = deepcopy(self.params)
         model_params.pop("_data_params")
+        model_params.pop("lagged_regressors")
         self.model = self.model_class(**model_params)
+        lagged_regressors = data_params.get("lagged_regressors", None)
+        if lagged_regressors is not None:
+            for lagged_regressor in lagged_regressors:
+                self.model.add_lagged_regressor(names=lagged_regressor)
         if custom_seasonalities is not None:
             for seasonality in custom_seasonalities:
                 self.model.add_seasonality(

--- a/tot/models/models_neuralprophet.py
+++ b/tot/models/models_neuralprophet.py
@@ -32,29 +32,44 @@ class NeuralProphetModel(Model):
         model_params = deepcopy(self.params)
         model_params.pop("_data_params")
 
+        # identifiy model_params
         if "lagged_regressors" in model_params.keys():
             model_params.pop("lagged_regressors")
-        if "lagged_regressors_config" in model_params.keys():
-            model_params.pop("lagged_regressors_config")
         if "future_regressors" in model_params.keys():
             model_params.pop("future_regressors")
-        if "future_regressors_config" in model_params.keys():
-            model_params.pop("future_regressors_config")
         self.model = self.model_class(**model_params)
+
+        # map lagged regressors
         lagged_regressors = self.params.get("lagged_regressors", None)
-        lagged_regressors_config = self.params.get("lagged_regressors_config", None)
-        if lagged_regressors is not None:
+        if isinstance(lagged_regressors, dict) is False and lagged_regressors is not None:
+            lagged_regressors_dict = {}
             for lagged_regressor in lagged_regressors:
+                lagged_regressors_dict.update({lagged_regressor: {}})
+            lagged_regressors = lagged_regressors_dict
+        if lagged_regressors is not None:
+            for lagged_regressor in lagged_regressors.keys():
                 self.model.add_lagged_regressor(
-                    names=lagged_regressor, **lagged_regressors_config[lagged_regressor]
-                ) if lagged_regressors_config is not None else self.model.add_lagged_regressor(names=lagged_regressor)
+                    names=lagged_regressor, **lagged_regressors[lagged_regressor]
+                ) if lagged_regressors[lagged_regressor] is not None else self.model.add_lagged_regressor(
+                    names=lagged_regressor
+                )
+
+        # map future regressors
         future_regressors = self.params.get("future_regressors", None)
-        future_regressors_config = self.params.get("future_regressors_config", None)
-        if future_regressors is not None:
+        if isinstance(future_regressors, dict) is False and future_regressors is not None:
+            future_regressors_dict = {}
             for future_regressor in future_regressors:
+                future_regressors_dict.update({future_regressor: {}})
+            future_regressors = future_regressors_dict
+        if future_regressors is not None:
+            for future_regressor in future_regressors.keys():
                 self.model.add_future_regressor(
-                    name=future_regressor, **future_regressors_config[future_regressor]
-                ) if future_regressors_config is not None else self.model.add_future_regressor(name=future_regressor)
+                    name=future_regressor, **future_regressors[future_regressor]
+                ) if future_regressors[future_regressor] is not None else self.model.add_future_regressor(
+                    name=future_regressor
+                )
+
+        # map custom_seasonalities
         if custom_seasonalities is not None:
             for seasonality in custom_seasonalities:
                 self.model.add_seasonality(


### PR DESCRIPTION
## :microscope: Background
`NeuralProphet` supports lagged and future regressors. In Test-of-Time we want to be able to compare `NeuralProphet `with added lagged and future regressors. Therefore, we add this capability to the initialization function of the `NeuralProphetModel`

## :crystal_ball: Key changes
- adapt `__post_init__()` to call the `model.add_lagged_regressors()` and `model.add_future_regressors()`
- add pytests to test all regressor configurations

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings.
- [x] Info: I have added required pytest

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/test-of-time/blob/main/CONTRIBUTING.md).