### PR TITLE
Rename conflicting params

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -252,7 +252,7 @@ def test_linear_regression_model():
     model_classes_and_params = [
         (
             LinearRegressionModel,
-            {"lags": 12, "output_chunk_length": 1, "n_forecasts": 4},
+            {"n_lags": 12, "output_chunk_length": 1, "n_forecasts": 4},
         ),
     ]
     log.debug("{}".format(model_classes_and_params))
@@ -280,7 +280,7 @@ def test_random_forest_model():
     model_classes_and_params = [
         (
             RandomForestModel,
-            {"lags": 12, "output_chunk_length": 1, "n_forecasts": 4},
+            {"n_lags": 12, "output_chunk_length": 1, "n_forecasts": 4},
         ),
     ]
     log.debug("{}".format(model_classes_and_params))
@@ -308,7 +308,7 @@ def test_darts_model():
     model_classes_and_params = [
         (
             DartsForecastingModel,
-            {"model": NaiveDrift, "retrain": True, "lags": 12, "n_forecasts": 4},
+            {"darts_model": NaiveDrift, "retrain": True, "n_lags": 12, "n_forecasts": 4},
         ),
     ]
     log.debug("{}".format(model_classes_and_params))

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -52,9 +52,9 @@ def test_basic_plot(plotting_backend):
         (NaiveModel, {"n_forecasts": 4}),
         (SeasonalNaiveModel, {"n_forecasts": 4, "season_length": 12}),
         (ProphetModel, {}),
-        (LinearRegressionModel, {"lags": 12, "output_chunk_length": 1, "n_forecasts": 4}),
-        (RandomForestModel, {"lags": 24, "output_chunk_length": 8, "n_forecasts": 8}),
-        (DartsForecastingModel, {"model": NaiveDrift, "retrain": True, "lags": 12, "n_forecasts": 4}),
+        (LinearRegressionModel, {"n_lags": 12, "output_chunk_length": 1, "n_forecasts": 4}),
+        (RandomForestModel, {"n_lags": 24, "output_chunk_length": 8, "n_forecasts": 8}),
+        (DartsForecastingModel, {"darts_model": NaiveDrift, "retrain": True, "n_lags": 12, "n_forecasts": 4}),
     ]
 
     benchmark = SimpleBenchmark(

--- a/tests/test_processing_panel_data.py
+++ b/tests/test_processing_panel_data.py
@@ -83,11 +83,11 @@ def test_benchmark_panel_data_input():
                 "global_time_normalization": True,
             },
         ),
-        (LinearRegressionModel, {"lags": 24, "output_chunk_length": 8, "n_forecasts": 8}),
+        (LinearRegressionModel, {"n_lags": 24, "output_chunk_length": 8, "n_forecasts": 8}),
         (NaiveModel, {"n_forecasts": 8}),
         (SeasonalNaiveModel, {"n_forecasts": 8, "season_length": 24}),
-        (RandomForestModel, {"lags": 24, "output_chunk_length": 8, "n_forecasts": 8}),
-        (DartsForecastingModel, {"model": NaiveDrift, "retrain": True, "lags": 12, "n_forecasts": 4}),
+        (RandomForestModel, {"n_lags": 24, "output_chunk_length": 8, "n_forecasts": 8}),
+        (DartsForecastingModel, {"darts_model": NaiveDrift, "retrain": True, "n_lags": 12, "n_forecasts": 4}),
     ]
     log.debug("{}".format(model_classes_and_params))
 

--- a/tot/experiment.py
+++ b/tot/experiment.py
@@ -54,9 +54,9 @@ class Experiment(ABC):
         if hasattr(self.data, "freq") and self.data.freq is not None:
             data_params["freq"] = self.data.freq
         self.params.update({"_data_params": data_params})
-        model_name = self.params.get("model", self.model_class).__name__
+        model_name = self.params.get("darts_model", self.model_class).__name__
         params_repr = self.params.copy()
-        params_repr.pop("model", None)
+        params_repr.pop("darts_model", None)
         if not hasattr(self, "experiment_name") or self.experiment_name is None:
             self.experiment_name = "{}_{}{}".format(
                 self.data.name,

--- a/tot/models/models_darts.py
+++ b/tot/models/models_darts.py
@@ -49,7 +49,7 @@ class DartsForecastingModel(Model):
     >>> model_classes_and_params = [
     >>>     (
     >>>         DartsForecastingModel,
-    >>>         {"model": NaiveDrift, "retrain": True, "lags": 12, "n_forecasts": 4},
+    >>>         {"darts_model": NaiveDrift, "retrain": True, "n_lags": 12, "n_forecasts": 4},
     >>>     ),
     >>> ]
     >>>
@@ -72,14 +72,14 @@ class DartsForecastingModel(Model):
                 "Requires darts to be installed:" "https://github.com/unit8co/darts/blob/master/INSTALL.md"
             )
         self.n_forecasts = self.params["n_forecasts"]
-        self.n_lags = self.params["lags"]
+        self.n_lags = self.params["n_lags"]
         self.retrain = self.params.get("retrain", False)
         model_params = deepcopy(self.params)
         model_params.pop("_data_params")
         model_params.pop("n_forecasts")
-        model_params.pop("lags")
+        model_params.pop("n_lags")
         model_params.pop("retrain", None)
-        model = model_params.pop("model")
+        model = model_params.pop("darts_model")
         self.model = model(**model_params)
 
     def fit(self, df: pd.DataFrame, freq: str) -> None:
@@ -173,12 +173,14 @@ class DartsRegressionModel(DartsForecastingModel):
         # n_forecasts is not a parameter of the model
         params.pop("n_forecasts")
         # overwrite output_chunk_length with n_forecasts
+        params.pop("n_lags")
         params.update({"output_chunk_length": self.params["n_forecasts"]})
+        params.update({"lags": self.params["n_lags"]})
         model = self.regression_class(n_jobs=-1)  # n_jobs=-1 indicates to use all processors
         params.update({"model": model})  # assign model
         self.model = self.model_class(**params)
         self.n_forecasts = self.params["n_forecasts"]
-        self.n_lags = params["lags"]
+        self.n_lags = self.params["n_lags"]
         # input checks are provided by model itself
 
 
@@ -192,7 +194,7 @@ class LinearRegressionModel(DartsRegressionModel):
     >>> model_classes_and_params = [
     >>>     (
     >>>         LinearRegressionModel,
-    >>>         {"lags": 12, "n_forecasts": 4},
+    >>>         {"n_lags": 12, "n_forecasts": 4},
     >>>     ),
     >>> ]
     >>>
@@ -219,7 +221,7 @@ class RandomForestModel(DartsRegressionModel):
     >>> model_classes_and_params = [
     >>>     (
     >>>         RandomForestModel,
-    >>>         {"lags": 12, "n_forecasts": 4},
+    >>>         {"n_lags": 12, "n_forecasts": 4},
     >>>     ),
     >>> ]
     >>>


### PR DESCRIPTION
To avoid naming conflict for some of the models `lags` param is renamed to `n_lags`. Now, `n_lags` param is used for pipeline configuration and should be equal to the model parameter specifying number of lags (depending on the model i.e. `input_chunk_length` or `lags`).

Similarly param `model` is now renamed to `darts_model`.